### PR TITLE
Add run-name to Linter Tests in GitHub Actions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,4 +1,5 @@
-name: Check eslint
+name: Check Eslint
+run-name: Test linter
 on:
   # Runs on pushes targeting the default branch
   push:


### PR DESCRIPTION
This commit adds the 'run-name' to the linter tests in GitHub Actions.