### PR TITLE
style :lipstick: Update layouts and spacing in salon pages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,7 @@ const HomePage: NextPage = async () => {
 
               <footer className='flex flex-col items-start justify-center'>
                 <button className='w-52 h-16 mt-1 p-2 font-normal border border-primary rounded transition-transform duration-300 ease-in-out transform hover:border-white hover:bg-primary hover:text-white'>
-                  <Link href={'/salon-page/prices'}>Ver todos</Link>
+                  <Link href={'/salon-page/salon-services'}>Ver todos</Link>
                 </button>
               </footer>
             </div>

--- a/src/app/salon-page/prices/page.tsx
+++ b/src/app/salon-page/prices/page.tsx
@@ -46,10 +46,7 @@ const PricesPage: NextPage = () => {
     <>
       <Hero title={title} urlImg={urlImg}></Hero>
 
-      <main className='flex flex-col items-center justify-center gap-y-4 py-4 w-full'>
-        <header className='flex justify-center p-3 text-black'>
-          <h1 className='text-2xl font-bold'>Lista de precios</h1>
-        </header>
+      <main className='flex flex-col items-center justify-center gap-y-4 py-4 w-full pt-10'>
 
         <div className='flex flex-col gap-6 px-2 w-full overflow-hidden'>
           <ListServicesPrice

--- a/src/app/salon-page/salon-about/page.tsx
+++ b/src/app/salon-page/salon-about/page.tsx
@@ -11,9 +11,8 @@ const ServicesPage: NextPage = () => {
     <>
       <Hero title={title} urlImg={urlImg}></Hero>
 
-      <main className='flex flex-col items-center justify-center gap-y-2 py-4'>
+      <main className='flex flex-col items-center justify-center gap-y-2 py-4 pt-10'>
         <header className='flex flex-col items-center justify-center p-3 text-black'>
-          <h1 className='text-2xl font-bold text-center'>Acerca de Nosotros</h1>
           <p>Actualmente en construcción</p>
         </header>
 

--- a/src/app/salon-page/salon-services/page.tsx
+++ b/src/app/salon-page/salon-services/page.tsx
@@ -45,11 +45,7 @@ const ServicesPage: NextPage = () => {
     <>
       <Hero title={title} urlImg={urlImg}></Hero>
 
-      <main className='flex flex-col items-center justify-center gap-y-4 py-4 w-full text-black'>
-        <header className='flex justify-center p-3'>
-          <h1 className='text-2xl font-bold'>Lista de servicios</h1>
-        </header>
-
+      <main className='flex flex-col items-center justify-center gap-y-4 py-4 w-full text-black pt-10'>
         <div className='flex flex-col gap-6 px-2 w-full overflow-hidden  max-w-[820px]'>
           <div className='flex flex-col'>
             <h1 className='py-1 font-semibold'>{titleManos}</h1>

--- a/src/components/dream-nails/GaleryImages.tsx
+++ b/src/components/dream-nails/GaleryImages.tsx
@@ -47,7 +47,7 @@ export function GaleryImages({ images }: ImageProps): JSX.Element {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-5xl">
+    <div className="container mx-auto px-4 py-12 max-w-5xl">
       <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         {
           images.map((image, index) => {


### PR DESCRIPTION
- Updated link in Home page button to point to 'salon-services' instead of 'prices' for accurate navigation.
- Adjusted padding and layout spacing on multiple salon pages (`salon-about`, `prices`, `salon-services`) to enhance consistency.
- Increased vertical padding in `GaleryImages` component for improved spacing and readability of gallery layout.