### PR TITLE
style :lipstick: update label text color for consistency

### DIFF
--- a/src/components/monedex/expenses/create-form.tsx
+++ b/src/components/monedex/expenses/create-form.tsx
@@ -119,7 +119,7 @@ export default function Form({
                 />
                 <label
                   htmlFor='cash'
-                  className='ml-2 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-white dark:text-gray-300'
+                  className='ml-2 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
                 >
                   Efectivo <BsCashStack className='h-4 w-4' />
                 </label>

--- a/src/components/monedex/expenses/edit-form.tsx
+++ b/src/components/monedex/expenses/edit-form.tsx
@@ -131,7 +131,7 @@ export default function EditExpenseForm({
                 />
                 <label
                   htmlFor='cash'
-                  className='ml-2 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-white dark:text-gray-300'
+                  className='ml-2 flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
                 >
                   Efectivo <BsCashStack className='h-4 w-4' />
                 </label>


### PR DESCRIPTION
- Changed the label text color for the "Efectivo" payment method in both the create and edit expense forms.
  - Updated text color to `text-gray-600` in light mode for better visibility and alignment with design standards.
  - Retained `dark:text-gray-300` for dark mode to maintain contrast.