### PR TITLE
feat: 💰 add physical balance tracking to wallets

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,7 @@ model Wallet {
   user_id    Int
   name       String
   balance    Float      @default(0)
+  physical   Float?     @default(0)
   type       WalletType @default(debit)
   created_at DateTime   @default(now())
   updated_at DateTime?

--- a/src/actions/monedex/wallets/get-all-wallet-summary.ts
+++ b/src/actions/monedex/wallets/get-all-wallet-summary.ts
@@ -41,6 +41,7 @@ export const getAllWalletsSummary = async ({
         id: true,
         name: true,
         balance: true,
+        physical: true,
         type: true,
         incomes: {
           where: {
@@ -74,6 +75,8 @@ export const getAllWalletsSummary = async ({
 
     let totalIncomeGlobal = 0
     let totalExpensesGlobal = 0
+    let totalPhysicalGlobal = 0
+    let totalBalanceGlobal = 0
 
     const walletsSummary = walletSummaryDb.map(wallet => {
       // calculate total income and expenses
@@ -85,15 +88,22 @@ export const getAllWalletsSummary = async ({
 
       // Calculate change in balance
       const balance = totalIncome - totalExpenses
+      totalBalanceGlobal += balance
       const changeValue = totalExpenses > 0 ? ((totalIncome - totalExpenses) / totalExpenses) * 100 : 0
       const changeLabel = 'Balance financiero'
+      const physical = wallet.physical ?? 0
+      totalPhysicalGlobal += physical
+      const difference = (wallet.physical ?? 0) - balance
+
+      const differencePercentage = balance !== 0 ? (difference / balance) * 100 : 0
 
       return {
         id: wallet.id,
         name: wallet.name,
         balance,
-        totalIncome,
-        totalExpenses,
+        differencePercentage,
+        physical,
+        difference,
         type: wallet.type,
         change: {
           value: changeValue,
@@ -102,6 +112,9 @@ export const getAllWalletsSummary = async ({
       }
     })
 
+    const globalDifference = totalPhysicalGlobal - totalBalanceGlobal
+    const globalDifferencePercentage =
+      totalBalanceGlobal !== 0 ? (globalDifference / totalBalanceGlobal) * 100 : 0
     const globalChangeValue = totalExpensesGlobal > 0
       ? ((totalIncomeGlobal - totalExpensesGlobal) / totalExpensesGlobal) * 100
       : 0
@@ -110,6 +123,9 @@ export const getAllWalletsSummary = async ({
       totalIncome: totalIncomeGlobal,
       totalExpenses: totalExpensesGlobal,
       totalBalance: totalIncomeGlobal - totalExpensesGlobal,
+      difference: globalDifference,
+      differencePercentage: globalDifferencePercentage,
+      physical: totalPhysicalGlobal,
       change: {
         value: globalChangeValue,
         label: globalChangeLabel

--- a/src/actions/monedex/wallets/update-wallet-physical.ts
+++ b/src/actions/monedex/wallets/update-wallet-physical.ts
@@ -1,0 +1,66 @@
+'use server'
+
+import { getUserSessionServer } from '@/actions'
+import { type UpdateWalletPhysical } from '@/interfaces/wallet-physical.interface'
+import prisma from '@/lib/prisma'
+
+const messages = {
+  success: 'Wallet physical amount updated successfully',
+  error: 'Error updating wallet physical amount',
+  notFound: 'Wallet not found',
+  unauthorized: 'You do not have permission to update this wallet'
+}
+
+export const updateWalletPhysical = async (data: UpdateWalletPhysical) => {
+  try {
+    const user = await getUserSessionServer()
+
+    if (!user) {
+      return {
+        ok: false,
+        message: messages.error
+      }
+    }
+
+    // Validate that the wallet belongs to the current user
+    const wallet = await prisma.wallet.findFirst({
+      where: {
+        id: data.walletId
+        // user_id: user.id
+      }
+    })
+
+    if (!wallet) {
+      return {
+        ok: false,
+        message: messages.notFound
+      }
+    }
+
+    // Validate that physicalAmount is a positive number
+    if (data.physicalAmount < 0) {
+      return {
+        ok: false,
+        message: 'Physical amount must be a positive number'
+      }
+    }
+
+    // Update only the physical field
+    const updatedWallet = await prisma.wallet.update({
+      where: { id: data.walletId },
+      data: { physical: data.physicalAmount }
+    })
+
+    return {
+      ok: true,
+      message: messages.success,
+      wallet: updatedWallet
+    }
+  } catch (error) {
+    console.error('Error updating wallet physical amount:', error)
+    return {
+      ok: false,
+      message: messages.error
+    }
+  }
+}

--- a/src/app/monedex/dashboard/page.tsx
+++ b/src/app/monedex/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { IoWalletOutline } from 'react-icons/io5'
 import { getAllWalletsSummary } from '@/actions/monedex/wallets/get-all-wallet-summary'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import { CategoryInsights } from '@/components/monedex/dashboard/category-insights'
@@ -10,6 +11,7 @@ import { SummaryCard } from '@/components/monedex/dashboard/summary-card'
 import { TopExpensesBarChart } from '@/components/monedex/dashboard/top-expenses-bar-chart'
 import FilterMonth from '@/components/monedex/filter-month'
 import { MetricCard } from '@/components/monedex/wallets/MetricCard'
+import { PhysicalAmountModal } from '@/components/monedex/wallets/physical-amount-modal'
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel'
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>
@@ -29,6 +31,14 @@ export default async function DashboardPage(props: {
     return <div>Wallet not found</div>
   }
 
+  const wallets = walletsSummary.map(wallet => {
+    return {
+      id: wallet.id,
+      name: wallet.name,
+      balance: wallet.balance
+    }
+  })
+
   return (
     <section className="container mx-auto p-4 space-y-6">
       <Breadcrumbs
@@ -39,14 +49,19 @@ export default async function DashboardPage(props: {
         <FilterMonth />
       </div>
 
+      {/* Physical Amount Modal Trigger */}
+      <div className="flex justify-end">
+        <PhysicalAmountModal wallets={wallets} />
+      </div>
+
       <>
         {/* Desktop view */}
         <div className="hidden md:grid md:grid-cols-2 gap-4">
-          <MetricCard title="Total" balance={globalSummary.totalBalance} totalIncome={globalSummary.totalIncome} totalExpenses={globalSummary.totalExpenses} change={{ value: globalSummary.change.value, label: globalSummary.change.label }} type="total" />
+          <MetricCard title="Total" balance={globalSummary.totalBalance} change={{ value: globalSummary.change.value, label: globalSummary.change.label }} difference={globalSummary.difference} differencePercentage={globalSummary.differencePercentage} physicalAmount={globalSummary.physical} type="total" />
           {
             walletsSummary.map((wallet) => (
               <div key={wallet.id}>
-                <MetricCard title={wallet.name} balance={wallet.balance} totalIncome={wallet.totalIncome} totalExpenses={wallet.totalExpenses} change={wallet.change} type={wallet.type} />
+                <MetricCard title={wallet.name} balance={wallet.balance} change={wallet.change} type={wallet.type} difference={wallet.difference} physicalAmount={wallet.physical} differencePercentage={wallet.differencePercentage} />
               </div>
             ))
           }
@@ -57,13 +72,13 @@ export default async function DashboardPage(props: {
           <Carousel className="w-full">
             <CarouselContent className="-ml-4">
               <CarouselItem key="total" className='pl-4 basis-[calc(100%-2rem)] first-letter'>
-                <MetricCard title="Total" balance={globalSummary.totalBalance} totalIncome={globalSummary.totalIncome} totalExpenses={globalSummary.totalExpenses} change={{ value: globalSummary.change.value, label: globalSummary.change.label }} type="total" />
+                <MetricCard title="Total" balance={globalSummary.totalBalance} change={{ value: globalSummary.change.value, label: globalSummary.change.label }} difference={globalSummary.difference} differencePercentage={globalSummary.differencePercentage} physicalAmount={globalSummary.physical} type="total" />
               </CarouselItem>
 
               {
                 walletsSummary.map((wallet) => (
                   <CarouselItem key={wallet.id} className='pl-4 basis-[calc(100%-2rem)] first-letter'>
-                    <MetricCard title={wallet.name} balance={wallet.balance} totalIncome={wallet.totalIncome} totalExpenses={wallet.totalExpenses} change={wallet.change} type={wallet.type} />
+                    <MetricCard title={wallet.name} balance={wallet.balance} change={wallet.change} type={wallet.type} difference={wallet.difference} physicalAmount={wallet.physical} differencePercentage={wallet.differencePercentage} />
                   </CarouselItem>
                 ))
               }
@@ -88,6 +103,19 @@ export default async function DashboardPage(props: {
       <CategoryInsights />
       <ExpenseManagement />
       <IncomeInsights />
+
+      {/* Physical vs Digital Section */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-monedex-secondary">Physical vs Digital Balance</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {/* Placeholder cards - will be populated with real data once Prisma client is regenerated */}
+          <div className="col-span-full text-center py-8 text-muted-foreground">
+            <IoWalletOutline className="w-12 h-12 mx-auto mb-4 opacity-50" />
+            <p>Physical vs Digital comparison will be displayed here</p>
+            <p className="text-sm">Update wallet physical amounts to see the comparison</p>
+          </div>
+        </div>
+      </div>
     </section>
   )
 }

--- a/src/components/diary/dashboard-overview.tsx
+++ b/src/components/diary/dashboard-overview.tsx
@@ -79,7 +79,7 @@ export function DashboardOverview({ thoughts, emotionSummary }: DashboardOvervie
               <CardTitle>Emotion Distribution</CardTitle>
               <CardDescription>Breakdown of your emotions during the selected period</CardDescription>
             </CardHeader>
-            <CardContent className="h-[400px]">
+            <CardContent className="h-[400px] px-1">
               {/* <EmotionDistributionChart emotionSummary={emotionSummary} /> */}
               {emotionSummary.length === 0
                 ? (<p className="text-muted-foreground">No emotion data for this period</p>)

--- a/src/components/diary/emotions/emotion-distribution-chart.tsx
+++ b/src/components/diary/emotions/emotion-distribution-chart.tsx
@@ -26,12 +26,13 @@ export function EmotionDistributionChart({ emotionSummary }: EmotionDistribution
           data={emotionSummary}
           cx="50%"
           cy="50%"
-          innerRadius={80}
-          outerRadius={120}
-          paddingAngle={2}
+          className='text-xs'
+          innerRadius={20}
+          outerRadius={80}
+          paddingAngle={1}
           dataKey="value"
           label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-          labelLine={false}
+          labelLine={true}
         >
           {emotionSummary.map((entry, index) => (
             <Cell key={`cell-${index}`} fill={entry.color} />

--- a/src/components/monedex/wallets/MetricCard.tsx
+++ b/src/components/monedex/wallets/MetricCard.tsx
@@ -8,8 +8,9 @@ import { cn } from '@/lib/utils'
 interface MetricCardProps {
   title: string
   balance: number
-  totalIncome: number
-  totalExpenses: number
+  physicalAmount?: number
+  difference: number
+  differencePercentage: number
   change: {
     value: number
     label: string
@@ -29,9 +30,9 @@ const iconColors = {
   total: 'bg-red-100 text-red-500'
 }
 
-export function MetricCard({ title, balance, totalIncome, totalExpenses, change, type }: MetricCardProps) {
+export function MetricCard({ title, balance, change, type, physicalAmount, difference, differencePercentage }: MetricCardProps) {
   const Icon = icons[type]
-  const isPositive = change.value > 0
+  const isPositive = differencePercentage > 0
 
   return (
     <Card className="border rounded-xl max-w-xl">
@@ -47,8 +48,8 @@ export function MetricCard({ title, balance, totalIncome, totalExpenses, change,
               <p className="text-2xl font-semibold">${balance.toFixed(2)}</p>
             </div>
 
-            <p className="text-sm text-muted-foreground">Total Ingresos: ${totalIncome.toFixed(2)}</p>
-            <p className="text-sm text-muted-foreground">Total Gastos: ${totalExpenses.toFixed(2)}</p>
+            <p className="text-sm text-muted-foreground">Físico: ${physicalAmount?.toFixed(2) ?? '0.00'}</p>
+            <p className="text-sm text-muted-foreground">Diferencia: ${difference?.toFixed(2) ?? '0.00'}</p>
 
             <div className="flex items-center gap-1 text-sm">
               <div
@@ -60,9 +61,8 @@ export function MetricCard({ title, balance, totalIncome, totalExpenses, change,
                 <span className="text-xs">
                   {isPositive ? '↗' : '↘'}
                 </span>
-                <span>{Math.abs(change.value).toFixed(2)}%</span>
+                <span>{differencePercentage?.toFixed(2) ?? '0.00'}%</span>
               </div>
-              <span className="text-muted-foreground">{change.label}</span>
             </div>
           </div>
         </div>

--- a/src/components/monedex/wallets/physical-amount-modal.tsx
+++ b/src/components/monedex/wallets/physical-amount-modal.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import toast from 'react-hot-toast'
+import { IoWalletOutline } from 'react-icons/io5'
+import { updateWalletPhysical } from '@/actions/monedex/wallets/update-wallet-physical'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { type UpdateWalletPhysical } from '@/interfaces/wallet-physical.interface'
+
+interface PhysicalAmountModalProps {
+  wallets: Array<{
+    id: number
+    name: string
+    balance: number
+  }>
+}
+
+export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
+  const [open, setOpen] = useState(false)
+  const [walletsLocal, setWalletsLocal] = useState<PhysicalAmountModalProps['wallets']>([])
+  const [selectedWalletId, setSelectedWalletId] = useState<string>('')
+  const [physicalAmount, setPhysicalAmount] = useState<string>('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Fetch wallets when modal opens
+  useEffect(() => {
+    if (open) {
+      fetchWallets()
+    }
+  }, [open])
+
+  const fetchWallets = async () => {
+    try {
+      setWalletsLocal(wallets)
+    } catch (error) {
+      toast.error('Error loading wallets')
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!selectedWalletId || !physicalAmount) {
+      toast.error('Please fill in all fields')
+      return
+    }
+
+    const amount = parseFloat(physicalAmount)
+    if (isNaN(amount) || amount < 0) {
+      toast.error('Please enter a valid positive amount')
+      return
+    }
+
+    setIsLoading(true)
+
+    try {
+      const data: UpdateWalletPhysical = {
+        walletId: parseInt(selectedWalletId),
+        physicalAmount: amount
+      }
+
+      const response = await updateWalletPhysical(data)
+
+      if (response.ok) {
+        toast.success('Physical amount updated successfully')
+        setOpen(false)
+        setSelectedWalletId('')
+        setPhysicalAmount('')
+        // Optionally refresh the page or update parent component
+        window.location.reload()
+      } else {
+        toast.error(response.message || 'Error updating physical amount')
+      }
+    } catch (error) {
+      toast.error('Error updating physical amount')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleOpenChange = (newOpen: boolean) => {
+    setOpen(newOpen)
+    if (!newOpen) {
+      // Reset form when closing
+      setSelectedWalletId('')
+      setPhysicalAmount('')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="gap-2">
+          <IoWalletOutline className="w-4 h-4" />
+          Update Physical Amount
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Update Physical Amount</DialogTitle>
+          <DialogDescription>
+            Set the physical cash amount for a wallet to compare with digital balance.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="wallet" className="col-span-4">
+                Wallet
+              </Label>
+              <div className="col-span-4">
+                <Select value={selectedWalletId} onValueChange={setSelectedWalletId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a wallet" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {walletsLocal.map((wallet) => (
+                      <SelectItem key={wallet.id} value={wallet.id.toString()}>
+                        <div className="flex items-center gap-2">
+                          <span>{wallet.name}</span>
+                          <span className="text-sm text-muted-foreground">
+                            (${wallet.balance.toFixed(2)})
+                          </span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="physicalAmount" className="col-span-4">
+                Physical Amount
+              </Label>
+              <div className="col-span-4">
+                <Input
+                  id="physicalAmount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder="0.00"
+                  value={physicalAmount}
+                  onChange={(e) => { setPhysicalAmount(e.target.value) }}
+                />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => { setOpen(false) }}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Saving...' : 'Save Physical Amount'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/interfaces/wallet-physical.interface.ts
+++ b/src/interfaces/wallet-physical.interface.ts
@@ -1,0 +1,4 @@
+export interface UpdateWalletPhysical {
+  walletId: number
+  physicalAmount: number
+}


### PR DESCRIPTION
### Changes Made
- feat: :card_file_box: add `physical` field to Wallet model in Prisma
- feat: :chart_with_upwards_trend: include physical and difference data in wallet summary action
- feat: :sparkles: extend dashboard to show physical vs digital balance section
- feat: :money_with_wings: update MetricCard to display physical amount and difference
- feat: :window: add PhysicalAmountModal trigger to dashboard layout
- style: :art: adjust diary emotion chart layout and spacing

### Description of Changes
- Added a new optional `physical` field in the Prisma `Wallet` model to store physical cash values.
- Updated `getAllWalletsSummary` to calculate physical totals, differences between recorded and physical balances, and percentage deviations.
- Extended the dashboard to include a “Physical vs Digital Balance” section with placeholders for future visualization.
- Enhanced `MetricCard` to display the physical balance and its difference from the digital one, providing a more comprehensive overview of real vs computed funds.
- Introduced `PhysicalAmountModal` to allow editing of wallet physical values directly from the dashboard.
- Adjusted UI elements, including padding and label spacing in the diary emotion chart for better visual alignment.

**Impact:** Enables tracking and visualization of physical vs digital wallet discrepancies, improving financial accuracy and management.