### PR TITLE
feat: 💰 add edit/delete budget category and modal actions

### DIFF
--- a/src/actions/monedex/budget/create-update-budget-category.ts
+++ b/src/actions/monedex/budget/create-update-budget-category.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 import { getUserSessionServer } from '@/actions'
 import prisma from '@/lib/prisma'
@@ -61,6 +62,8 @@ export const createUpdateBudgetCategory = async (data: BudgetCategoryFormData) =
         }
       })
 
+      revalidatePath('/monedex/budget')
+
       return {
         ok: true,
         message: messages.success,
@@ -74,6 +77,8 @@ export const createUpdateBudgetCategory = async (data: BudgetCategoryFormData) =
           amount: validatedData.amount
         }
       })
+
+      revalidatePath('/monedex/budget')
 
       return {
         ok: true,

--- a/src/actions/monedex/budget/delete-budget-category.ts
+++ b/src/actions/monedex/budget/delete-budget-category.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
 import { getUserSessionServer } from '@/actions'
 import prisma from '@/lib/prisma'
 
@@ -39,6 +40,8 @@ export const deleteBudgetCategory = async (id: number) => {
     await prisma.budgetCategory.delete({
       where: { id }
     })
+
+    revalidatePath('/monedex/budget')
 
     return {
       ok: true,

--- a/src/app/monedex/budget/page.tsx
+++ b/src/app/monedex/budget/page.tsx
@@ -100,6 +100,7 @@ export default async function BudgetPage(props: {
               {budgetCategories.map((category) => (
                 <BudgetCard
                   key={category.id}
+                  id={category.id}
                   name={category.name}
                   budgetAmount={category.budgetAmount}
                   paidAmount={category.paidAmount}

--- a/src/app/monedex/dashboard/page.tsx
+++ b/src/app/monedex/dashboard/page.tsx
@@ -34,13 +34,15 @@ export default async function DashboardPage(props: {
         breadcrumbs={[{ label: 'Wallets', href: '/monedex/wallets', active: true }]}
       />
 
-      <div className='flex flex-col gap-2 text-monedex-secondary'>
-        <FilterMonth />
-      </div>
+      <div className='flex justify-between'>
+        <div className='flex flex-col gap-2 w-full text-monedex-secondary'>
+          <FilterMonth />
+        </div>
 
-      {/* Physical Amount Modal Trigger */}
-      <div className="flex justify-end">
-        <PhysicalAmountModal wallets={wallets} />
+        {/* Physical Amount Modal Trigger */}
+        <div>
+          <PhysicalAmountModal wallets={wallets} />
+        </div>
       </div>
 
       <div className="flex flex-col md:grid md:grid-cols-2 gap-4 ">

--- a/src/components/monedex/budget/BudgetCard.tsx
+++ b/src/components/monedex/budget/BudgetCard.tsx
@@ -1,7 +1,18 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { FiEdit2, FiTrash2, FiCheck, FiX } from 'react-icons/fi'
+import { createUpdateBudgetCategory } from '@/actions/monedex/budget/create-update-budget-category'
+import { deleteBudgetCategory } from '@/actions/monedex/budget/delete-budget-category'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
 interface BudgetCardProps {
+  id: number
   name: string
   budgetAmount: number
   paidAmount: number
@@ -10,26 +21,181 @@ interface BudgetCardProps {
 }
 
 export function BudgetCard({
+  id,
   name,
   budgetAmount,
   paidAmount,
   difference,
   differencePercentage
 }: BudgetCardProps) {
+  const router = useRouter()
+  const [isEditing, setIsEditing] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [editData, setEditData] = useState({
+    name,
+    budgetAmount: budgetAmount.toString()
+  })
+
   const isOverBudget = difference < 0
   const isPositive = difference >= 0
+
+  const handleEdit = () => {
+    setIsEditing(true)
+    setEditData({
+      name,
+      budgetAmount: budgetAmount.toString()
+    })
+  }
+
+  const handleCancelEdit = () => {
+    setIsEditing(false)
+    setEditData({
+      name,
+      budgetAmount: budgetAmount.toString()
+    })
+  }
+
+  const handleSaveEdit = async () => {
+    if (!editData.name.trim() || !editData.budgetAmount) {
+      toast.error('Por favor complete todos los campos')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const result = await createUpdateBudgetCategory({
+        id,
+        name: editData.name.trim(),
+        amount: parseFloat(editData.budgetAmount)
+      })
+
+      if (result.ok) {
+        toast.success('Categoría actualizada correctamente')
+        setIsEditing(false)
+        router.refresh() // Refresh the page data
+      } else {
+        toast.error(result.message || 'Error al actualizar la categoría')
+      }
+    } catch (error) {
+      toast.error('Error inesperado al actualizar la categoría')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!confirm('¿Está seguro de que desea eliminar esta categoría de presupuesto?')) {
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const result = await deleteBudgetCategory(id)
+
+      if (result.ok) {
+        toast.success('Categoría eliminada correctamente')
+        router.refresh() // Refresh the page data
+      } else {
+        toast.error(result.message || 'Error al eliminar la categoría')
+      }
+    } catch (error) {
+      toast.error('Error inesperado al eliminar la categoría')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleInputChange = (field: string, value: string) => {
+    setEditData(prev => ({
+      ...prev,
+      [field]: value
+    }))
+  }
 
   return (
     <Card className="border rounded-xl w-full mx-auto">
       <CardHeader className="pb-3">
-        <CardTitle className="text-base font-semibold text-monedex-secondary">
-          {name}
-        </CardTitle>
+        <div className="flex items-center justify-between">
+          {isEditing
+            ? (
+              <Input
+                value={editData.name}
+                onChange={(e) => { handleInputChange('name', e.target.value) }}
+                disabled={isSubmitting}
+                className="text-base font-semibold text-monedex-secondary"
+                placeholder="Nombre de la categoría"
+              />)
+            : (
+              <CardTitle className="text-base font-semibold text-monedex-secondary">
+                {name}
+              </CardTitle>)}
+
+          <div className="flex gap-1">
+            {isEditing
+              ? (
+                <>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={handleSaveEdit}
+                    disabled={isSubmitting}
+                    className="h-8 w-8 p-0 text-green-600 hover:text-green-700 hover:bg-green-50"
+                  >
+                    <FiCheck className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={handleCancelEdit}
+                    disabled={isSubmitting}
+                    className="h-8 w-8 p-0 text-gray-600 hover:text-gray-700 hover:bg-gray-50"
+                  >
+                    <FiX className="h-4 w-4" />
+                  </Button>
+                </>)
+              : (
+                <>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={handleEdit}
+                    disabled={isSubmitting}
+                    className="h-8 w-8 p-0 text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+                  >
+                    <FiEdit2 className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={handleDelete}
+                    disabled={isSubmitting}
+                    className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
+                  >
+                    <FiTrash2 className="h-4 w-4" />
+                  </Button>
+                </>)}
+          </div>
+        </div>
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex justify-between items-center">
           <span className="text-sm text-muted-foreground">Presupuesto asignado</span>
-          <span className="text-sm font-medium">${budgetAmount.toFixed(2)}</span>
+          {isEditing
+            ? (
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                value={editData.budgetAmount}
+                onChange={(e) => { handleInputChange('budgetAmount', e.target.value) }}
+                disabled={isSubmitting}
+                className="w-24 text-sm font-medium text-right"
+                placeholder="0.00"
+              />)
+            : (
+              <span className="text-sm font-medium">${budgetAmount.toFixed(2)}</span>)}
         </div>
 
         <div className="flex justify-between items-center">

--- a/src/components/monedex/budget/BudgetCategoryForm.tsx
+++ b/src/components/monedex/budget/BudgetCategoryForm.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { createUpdateBudgetCategory } from '@/actions/monedex/budget/create-update-budget-category'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface BudgetCategoryFormProps {
+  onSuccess?: () => void
+}
+
+export function BudgetCategoryForm({ onSuccess }: BudgetCategoryFormProps) {
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [formData, setFormData] = useState({
+    name: '',
+    amount: ''
+  })
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!formData.name.trim() || !formData.amount) {
+      toast.error('Por favor complete todos los campos')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const result = await createUpdateBudgetCategory({
+        name: formData.name.trim(),
+        amount: parseFloat(formData.amount)
+      })
+
+      if (result.ok) {
+        toast.success('Categoría de presupuesto creada correctamente')
+        setFormData({ name: '', amount: '' })
+        router.refresh() // Refresh the page data
+        onSuccess?.()
+      } else {
+        toast.error(result.message || 'Error al crear la categoría')
+      }
+    } catch (error) {
+      toast.error('Error inesperado al crear la categoría')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleChange = (field: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }))
+  }
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle className="text-monedex-primary">Nueva Categoría de Presupuesto</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="name">Nombre de la categoría</Label>
+            <Input
+              id="name"
+              type="text"
+              placeholder="Ej: Despensa, Transporte"
+              value={formData.name}
+              onChange={(e) => { handleChange('name', e.target.value) }}
+              disabled={isSubmitting}
+              className="mt-1"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="amount">Monto asignado ($)</Label>
+            <Input
+              id="amount"
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="0.00"
+              value={formData.amount}
+              onChange={(e) => { handleChange('amount', e.target.value) }}
+              disabled={isSubmitting}
+              className="mt-1"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-monedex-tertiary hover:bg-monedex-tertiary/90 text-monedex-light"
+          >
+            {isSubmitting ? 'Creando...' : 'Crear Categoría'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/monedex/budget/BudgetModal.tsx
+++ b/src/components/monedex/budget/BudgetModal.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { BudgetCategoryForm } from './BudgetCategoryForm'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+
+interface BudgetModalProps {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+export function BudgetModal({ open, onOpenChange }: BudgetModalProps) {
+  const router = useRouter()
+
+  const handleSuccess = () => {
+    onOpenChange?.(false)
+    router.refresh() // Refresh the page data after successful creation
+  }
+
+  // Handle escape key and outside click
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open) {
+        onOpenChange?.(false)
+      }
+    }
+
+    if (open) {
+      document.addEventListener('keydown', handleEscape)
+      return () => { document.removeEventListener('keydown', handleEscape) }
+    }
+  }, [open, onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Crear Nueva Categoría de Presupuesto</DialogTitle>
+          <DialogDescription>
+            Agregue una nueva categoría para organizar sus presupuestos mensuales.
+          </DialogDescription>
+        </DialogHeader>
+        <BudgetCategoryForm onSuccess={handleSuccess} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/monedex/button-floating-menu.tsx
+++ b/src/components/monedex/button-floating-menu.tsx
@@ -2,6 +2,8 @@
 
 import { Plus } from 'lucide-react'
 import { usePathname, useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { BudgetModal } from '@/components/monedex/budget/BudgetModal'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -13,6 +15,7 @@ import {
 const menuItems = [
   { label: 'Crear gasto', path: '/monedex/expenses/create' },
   { label: 'Crear ingreso', path: '/monedex/incomes/create' },
+  { label: 'Crear presupuesto', path: '/monedex/budget', action: 'modal' },
   { label: 'Crear categoría', path: '/monedex/categories/create' },
   { label: 'Crear lugar', path: '/monedex/places/create' }
 ]
@@ -20,6 +23,7 @@ const menuItems = [
 export function FloatingMenuButton() {
   const router = useRouter()
   const pathname = usePathname()
+  const [isBudgetModalOpen, setIsBudgetModalOpen] = useState(false)
 
   const models = ['expenses', 'incomes', 'places', 'categories']
 
@@ -34,8 +38,12 @@ export function FloatingMenuButton() {
     return null
   }
 
-  const handleItemClick = (path: string) => {
-    router.push(path)
+  const handleItemClick = (path: string, action?: string) => {
+    if (action === 'modal') {
+      setIsBudgetModalOpen(true)
+    } else {
+      router.push(path)
+    }
   }
 
   return (
@@ -54,12 +62,18 @@ export function FloatingMenuButton() {
         {menuItems.map((item) => (
           <DropdownMenuItem
             key={item.path}
-            onSelect={() => { handleItemClick(item.path) }}
+            onSelect={() => { handleItemClick(item.path, item.action) }}
           >
             {item.label}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
+
+      {/* Budget Modal */}
+      <BudgetModal
+        open={isBudgetModalOpen}
+        onOpenChange={setIsBudgetModalOpen}
+      />
     </DropdownMenu>
   )
 }

--- a/src/components/monedex/logo-app.tsx
+++ b/src/components/monedex/logo-app.tsx
@@ -4,7 +4,7 @@ import { arapey } from '@/config/fonts'
 export default function AppLogo() {
   return (
     <div
-      className={`${arapey.className} flex flex-row items-center leading-none gap-x-3 text-monedex-light md:flex-col md:items-start md:gap-y-3`}
+      className={`${arapey.className} flex flex-row items-center leading-none gap-x-3 text-monedex-light md:items-start md:gap-y-3`}
     >
       <FaSackDollar className="h-8 w-8 rotate-[-10deg] md:h-12 md:w-12" />
       <p className="text-[44px]">Monedex</p>

--- a/src/components/monedex/nav-links.tsx
+++ b/src/components/monedex/nav-links.tsx
@@ -40,9 +40,9 @@ export default function NavLinks() {
             href={link.href}
             className={clsx(
               'flex w-full h-[52px] grow items-center justify-center gap-3 rounded-lg p-3 text-sm md:text-base font-medium transition-all duration-200 md:flex-none md:justify-start md:px-4',
-              'text-monedex-light/80 hover:text-monedex-light hover:bg-monedex-foreground/80',
+              'text-monedex-light/80 hover:text-monedex-light ',
               {
-                'bg-monedex-secondary text-monedex-light shadow-sm': isActive
+                'bg-monedex-foreground/80 text-monedex-light shadow-sm': isActive
               }
             )}
           >

--- a/src/components/monedex/sidenav.tsx
+++ b/src/components/monedex/sidenav.tsx
@@ -6,7 +6,7 @@ export default function SideNav() {
   return (
     <>
       <Link
-        className="flex h-20 items-center justify-start  bg-monedex-foreground/80 px-4 md:h-20 md:mb-8 hover:bg-monedex-foreground transition-colors"
+        className="flex h-20 md:h-28 items-center justify-start  bg-monedex-foreground/80 px-4 md:mb-3 hover:bg-monedex-foreground transition-colors"
         href="/monedex"
       >
         <div className="text-monedex-light">

--- a/src/components/monedex/wallets/physical-amount-modal.tsx
+++ b/src/components/monedex/wallets/physical-amount-modal.tsx
@@ -142,7 +142,7 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="outline" className="gap-2">
+        <Button variant="outline" size={'sm'} className="gap-2">
           <IoWalletOutline className="w-4 h-4" />
           <span className='hidden sm:block'>Update Physical Amount</span>
         </Button>


### PR DESCRIPTION
Changes Made

feat: 💾 add revalidatePath to budget actions for live updates

feat: 💰 enable edit and delete in BudgetCard with inline form and toast

feat: 🧭 add id prop to BudgetCard for CRUD operations

feat: 🪟 integrate budget modal into floating action menu

style: 🎨 adjust dashboard layout for better alignment

Description of Changes

Added revalidatePath('/monedex/budget') in create, update, and delete server actions to ensure UI updates instantly after any category modification.

Updated BudgetCard to support inline editing and deletion of budget categories using Next.js server actions (createUpdateBudgetCategory, deleteBudgetCategory), local state management, and toast notifications for user feedback.

Modified BudgetPage to pass the id to BudgetCard, enabling correct server action linkage.

Enhanced FloatingMenuButton to open a BudgetModal when the user selects “Crear presupuesto”, allowing budget creation without leaving the page.

Refined dashboard layout with flex alignment for the month filter and physical amount modal.

These changes complete the CRUD workflow for budget categories, improving UX by enabling direct management within the interface and ensuring consistent revalidation after each operation.