### PR TITLE
feat: 💳 propagate expense category ID through budget UI

### DIFF
--- a/src/actions/monedex/budget/get-budget-summary.ts
+++ b/src/actions/monedex/budget/get-budget-summary.ts
@@ -136,7 +136,8 @@ export const getBudgetSummary = async ({
         budgetAmount: category.amount,
         paidAmount,
         difference,
-        differencePercentage
+        differencePercentage,
+        expenseCategoryId: category.expense_category_id
       }
     })
 

--- a/src/app/monedex/budget/page.tsx
+++ b/src/app/monedex/budget/page.tsx
@@ -106,6 +106,7 @@ export default async function BudgetPage(props: {
                   paidAmount={category.paidAmount}
                   difference={category.difference}
                   differencePercentage={category.differencePercentage}
+                  expenseCategoryId={category.expenseCategoryId}
                 />
               ))}
             </div>)}

--- a/src/components/monedex/budget/BudgetCard.tsx
+++ b/src/components/monedex/budget/BudgetCard.tsx
@@ -18,6 +18,7 @@ interface BudgetCardProps {
   paidAmount: number
   difference: number
   differencePercentage: number
+  expenseCategoryId: number
 }
 
 export function BudgetCard({
@@ -26,14 +27,16 @@ export function BudgetCard({
   budgetAmount,
   paidAmount,
   difference,
-  differencePercentage
+  differencePercentage,
+  expenseCategoryId
 }: BudgetCardProps) {
   const router = useRouter()
   const [isEditing, setIsEditing] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [editData, setEditData] = useState({
     name,
-    budgetAmount: budgetAmount.toString()
+    budgetAmount: budgetAmount.toString(),
+    expenseCategoryId
   })
 
   const isOverBudget = difference < 0
@@ -43,7 +46,8 @@ export function BudgetCard({
     setIsEditing(true)
     setEditData({
       name,
-      budgetAmount: budgetAmount.toString()
+      budgetAmount: budgetAmount.toString(),
+      expenseCategoryId
     })
   }
 
@@ -51,7 +55,8 @@ export function BudgetCard({
     setIsEditing(false)
     setEditData({
       name,
-      budgetAmount: budgetAmount.toString()
+      budgetAmount: budgetAmount.toString(),
+      expenseCategoryId
     })
   }
 
@@ -67,7 +72,8 @@ export function BudgetCard({
       const result = await createUpdateBudgetCategory({
         id,
         name: editData.name.trim(),
-        amount: parseFloat(editData.budgetAmount)
+        amount: parseFloat(editData.budgetAmount),
+        expense_category_id: editData.expenseCategoryId
       })
 
       if (result.ok) {

--- a/src/components/monedex/budget/BudgetModal.tsx
+++ b/src/components/monedex/budget/BudgetModal.tsx
@@ -40,9 +40,9 @@ export function BudgetModal({ open, onOpenChange }: BudgetModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px] text-start">
         <DialogHeader>
-          <DialogTitle>Crear Nueva Categoría de Presupuesto</DialogTitle>
+          <DialogTitle>Crear nueva categoría de presupuesto</DialogTitle>
           <DialogDescription>
             Agregue una nueva categoría para organizar sus presupuestos mensuales.
           </DialogDescription>


### PR DESCRIPTION
### Changes Made
- feat: :zap: include `expense_category_id` in getBudgetSummary results
- feat: :art: pass `expenseCategoryId` prop to BudgetCard from page
- feat: :art: add `expenseCategoryId` state to BudgetCard for editing
- feat: :art: send `expense_category_id` on budget update from BudgetCard
- style: :art: adjust BudgetModal title capitalization and content alignment

### Description of Changes
- `getBudgetSummary` now returns `expense_category_id` for each budget category to maintain category linkage in the UI.
- `BudgetPage` passes the `expenseCategoryId` to each `BudgetCard` for accurate display and editing.
- `BudgetCard` now tracks `expenseCategoryId` in its edit state and sends it when updating a budget category to preserve the category relation.
- Minor UI adjustments in `BudgetModal` for consistent text alignment and title formatting.