### PR TITLE
feat: 💰 add income totals and split unbudgeted expenses

### DIFF
--- a/src/actions/monedex/incomes/get-income-by-category.ts
+++ b/src/actions/monedex/incomes/get-income-by-category.ts
@@ -1,0 +1,56 @@
+'use server'
+
+import prisma from '@/lib/prisma'
+
+export async function getIncomeByCategory(month: number, year: number) {
+  try {
+    const startDate = new Date(year, month - 1, 1)
+    const endDate = new Date(year, month, 0)
+
+    const incomeByCategory = await prisma.income.groupBy({
+      by: ['income_category_id'],
+      where: {
+        income_month: month,
+        income_date: {
+          gte: startDate,
+          lt: endDate
+        }
+      },
+      _sum: {
+        amount: true
+      },
+      orderBy: {
+        _sum: {
+          amount: 'desc'
+        }
+      }
+    })
+
+    // Get category names
+    const categoryIds = incomeByCategory.map(item => item.income_category_id)
+    const categories = await prisma.incomeCategory.findMany({
+      where: {
+        id: {
+          in: categoryIds
+        }
+      }
+    })
+
+    const categoryMap = new Map(categories.map(cat => [cat.id, cat.name]))
+
+    const result = incomeByCategory.map(item => ({
+      categoryId: item.income_category_id,
+      categoryName: categoryMap.get(item.income_category_id) || 'Unknown',
+      total: item._sum.amount || 0
+    }))
+
+    const totalIncome = result.reduce((sum, item) => sum + item.total, 0)
+
+    return {
+      incomeByCategory: result,
+      totalIncome
+    }
+  } catch (error) {
+    throw new Error('Failed to fetch income by category.')
+  }
+}

--- a/src/app/monedex/budget/page.tsx
+++ b/src/app/monedex/budget/page.tsx
@@ -1,9 +1,7 @@
 import { RiMoneyDollarCircleLine, RiWalletLine, RiTimeLine } from 'react-icons/ri'
 import { getBudgetSummary } from '@/actions/monedex/budget/get-budget-summary'
-import { getUnbudgetedExpenses } from '@/actions/monedex/budget/get-unbudgeted-expenses'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import SelectableBudgetCards from '@/components/monedex/budget/SelectableBudgetCards'
-import { UnbudgetedExpensesSection } from '@/components/monedex/budget/UnbudgetedExpensesSection'
 import FilterMonth from '@/components/monedex/filter-month'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
@@ -19,7 +17,6 @@ export default async function BudgetPage(props: {
   const year = Number(searchParams.year) || currentYear
 
   const { budgetCategories, globalSummary } = await getBudgetSummary({ month, year })
-  const { unbudgetedExpenses, totalUnbudgeted } = await getUnbudgetedExpenses({ month, year })
 
   if (!budgetCategories || !globalSummary) {
     return <div>Error loading budget data</div>
@@ -110,12 +107,6 @@ export default async function BudgetPage(props: {
               <SelectableBudgetCards categories={budgetCategories} field="budgetAmount" />
             </div>)}
       </div>
-
-      {/* Unbudgeted Expenses */}
-      <UnbudgetedExpensesSection
-        categories={unbudgetedExpenses || []}
-        total={totalUnbudgeted || 0}
-      />
     </section>
   )
 }

--- a/src/app/monedex/incomes/page.tsx
+++ b/src/app/monedex/incomes/page.tsx
@@ -1,8 +1,10 @@
 import { type Metadata } from 'next'
 import { fetchTotalIcomesPages } from '@/actions/monedex/incomes/fetch-total-incomes-pages'
+import { getIncomeByCategory } from '@/actions/monedex/incomes/get-income-by-category'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import FilterMonth from '@/components/monedex/filter-month'
 import { CreateIncome } from '@/components/monedex/incomes/income-buttons'
+import IncomeByCategorySection from '@/components/monedex/incomes/income-by-category'
 import IncomesTable from '@/components/monedex/incomes/income-table'
 import Pagination from '@/components/monedex/pagination'
 import Search from '@/components/monedex/search'
@@ -26,21 +28,25 @@ export default async function IncomesPage(props: {
   const currentPage = Number(searchParams?.page) || 1
 
   const totalPages = await fetchTotalIcomesPages(query, Number(month), Number(year))
+  const { incomeByCategory, totalIncome } = await getIncomeByCategory(Number(month), Number(year))
 
   return (
-    <main>
+    <main className='container mx-auto space-y-6'>
       <Breadcrumbs
         breadcrumbs={[{ label: 'Ingresos', href: '/monedex/incomes', active: true }]}
       />
+
+      <div className='flex flex-col gap-2'>
+        <FilterMonth />
+      </div>
+
+      <IncomeByCategorySection incomeByCategory={incomeByCategory} totalIncome={totalIncome} />
+
       <div className='my-3 flex items-center justify-between gap-2 md:mt-8'>
         <Search placeholder='Buscar gastos...' />
         <div className='hidden md:block'>
           <CreateIncome />
         </div>
-      </div>
-
-      <div className='flex flex-col gap-2'>
-        <FilterMonth />
       </div>
 
       <div className='flex flex-col gap-2 pt-5'>

--- a/src/app/monedex/unbudgeted-expenses/page.tsx
+++ b/src/app/monedex/unbudgeted-expenses/page.tsx
@@ -1,0 +1,58 @@
+import { type Metadata } from 'next'
+import { getUnbudgetedExpenses } from '@/actions/monedex/budget/get-unbudgeted-expenses'
+import Breadcrumbs from '@/components/monedex/breadcrumbs'
+import { UnbudgetedExpensesSection } from '@/components/monedex/budget/UnbudgetedExpensesSection'
+import FilterMonth from '@/components/monedex/filter-month'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatCurrency } from '@/lib/helpers'
+import { TbCurrencyDollar } from 'react-icons/tb'
+
+export const metadata: Metadata = {
+  title: 'Gastos sin Presupuesto'
+}
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>
+
+export default async function UnbudgetedExpensesPage(props: {
+  searchParams: SearchParams
+}) {
+  const searchParams = await props.searchParams
+  const currentMonth = new Date().getMonth() + 1
+  const currentYear = new Date().getFullYear()
+  const month = Number(searchParams.month) || Number(currentMonth)
+  const year = Number(searchParams.year) || currentYear
+
+  const { unbudgetedExpenses, totalUnbudgeted } = await getUnbudgetedExpenses({ month, year })
+
+  return (
+    <section className="container mx-auto space-y-6">
+      <Breadcrumbs
+        breadcrumbs={[{ label: 'Gastos sin Presupuesto', href: '/monedex/unbudgeted-expenses', active: true }]}
+      />
+
+      <div className='flex flex-col gap-2 text-monedex-secondary'>
+        <FilterMonth />
+      </div>
+
+      {/* Total Unbudgeted Expenses Card */}
+      <Card className="border rounded-xl bg-red-50">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Gastos Sin Presupuesto</CardTitle>
+          <TbCurrencyDollar className="h-4 w-4 text-red-600" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-3xl font-bold text-red-600">{formatCurrency(totalUnbudgeted || 0)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {unbudgetedExpenses?.length || 0} categorías sin presupuesto
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Unbudgeted Expenses */}
+      <UnbudgetedExpensesSection
+        categories={unbudgetedExpenses || []}
+        total={totalUnbudgeted || 0}
+      />
+    </section>
+  )
+}

--- a/src/components/monedex/budget/SelectableUnbudgetedCards.tsx
+++ b/src/components/monedex/budget/SelectableUnbudgetedCards.tsx
@@ -77,7 +77,7 @@ export default function SelectableUnbudgetedCards({ categories }: { categories: 
                         ))}
                       </div>
                       {/* Gradient overlay */}
-                      <div className="absolute bottom-0 left-0 right-0 h-7 pointer-events-none bg-gradient-to-t from-white to-transparent" />
+                      <div className="absolute bottom-0 left-0 right-0 h-7 pointer-events-none bg-gradient-to-t from-white to-transparent rounded-xl" />
                     </div>
                   </CardContent>
                 </Card>

--- a/src/components/monedex/incomes/income-by-category.tsx
+++ b/src/components/monedex/incomes/income-by-category.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatCurrency } from '@/lib/helpers'
+
+interface IncomeCategory {
+  categoryId: number
+  categoryName: string
+  total: number
+}
+
+interface IncomeByCategoryProps {
+  incomeByCategory: IncomeCategory[]
+  totalIncome: number
+}
+
+export default function IncomeByCategorySection({ incomeByCategory, totalIncome }: IncomeByCategoryProps) {
+  return (
+    <div className="space-y-4">
+
+      {incomeByCategory.length > 0 && (
+        <Card className="border rounded-xl bg-green-50">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Resumen Total de Ingresos</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold text-green-600">{formatCurrency(totalIncome)}</div>
+            <div className="text-sm text-muted-foreground">
+              {incomeByCategory.length} {incomeByCategory.length === 1 ? 'categoría' : 'categorías'}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {incomeByCategory.map((category) => (
+          <Card key={category.categoryId} className="border rounded-xl">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base text-monedex-primary">{category.categoryName}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="text-2xl font-bold text-green-600">{formatCurrency(category.total)}</div>
+              <div className="text-xs text-muted-foreground">Total por categoría</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/monedex/nav-links.tsx
+++ b/src/components/monedex/nav-links.tsx
@@ -19,6 +19,7 @@ const primaryLinks = [
 ]
 
 const secondaryLinks = [
+  { name: 'Gastos sin Presupuesto', href: '/monedex/unbudgeted-expenses', icon: TbCurrencyDollar },
   { name: 'Categorías', href: '/monedex/categories', icon: BiCategory },
   { name: 'Lugares', href: '/monedex/places', icon: BiLocationPlus },
   { name: 'Diario', href: '/diary', icon: BsJournalText }


### PR DESCRIPTION
### Changes Made
- feat: 💰 add totals section to incomes page
- feat: 💸 split unbudgeted expenses into separate view
- style: 🎨 adjust gradient overlay with rounded edges
- feat: 🧭 add unbudgeted expenses link to sidebar nav
- refactor: 🔧 remove unbudgeted logic from budget page
- feat: 📊 add income-by-category section

### Description of Changes
- Added a totals summary to the incomes page using `getIncomeByCategory`, allowing users to view total income and category-level distribution.
- Extracted unbudgeted expenses into a standalone route, cleaning up the budget page and improving navigation.
- Added a new sidebar navigation link for quick access to unbudgeted expenses.
- Improved UI styling by rounding the bottom gradient overlay in `SelectableUnbudgetedCards`.
- Reorganized layout on the incomes page to prioritize filters and totals for a better user experience.