### PR TITLE
Feat/calculator amount inputs

### DIFF
--- a/src/actions/monedex/budget/create-update-budget-category.ts
+++ b/src/actions/monedex/budget/create-update-budget-category.ts
@@ -91,6 +91,7 @@ export const createUpdateBudgetCategory = async (data: BudgetCategoryFormData) =
       }
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error saving budget category:', error)
 
     if (error instanceof z.ZodError) {

--- a/src/actions/monedex/budget/delete-budget-category.ts
+++ b/src/actions/monedex/budget/delete-budget-category.ts
@@ -48,6 +48,7 @@ export const deleteBudgetCategory = async (id: number) => {
       message: messages.success
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error deleting budget category:', error)
     return {
       ok: false,

--- a/src/actions/monedex/budget/get-budget-categories.ts
+++ b/src/actions/monedex/budget/get-budget-categories.ts
@@ -42,6 +42,7 @@ export const getBudgetCategories = async () => {
       budgetCategories
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error getting budget categories:', error)
     return {
       ok: false,

--- a/src/actions/monedex/budget/get-budget-summary.ts
+++ b/src/actions/monedex/budget/get-budget-summary.ts
@@ -160,6 +160,7 @@ export const getBudgetSummary = async ({
       globalSummary
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error getting budget summary:', error)
     return {
       ok: false,

--- a/src/actions/monedex/budget/get-expense-categories.ts
+++ b/src/actions/monedex/budget/get-expense-categories.ts
@@ -38,6 +38,7 @@ export const getExpenseCategories = async () => {
       expenseCategories
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error getting expense categories:', error)
     return {
       ok: false,

--- a/src/actions/monedex/wallets/update-wallet-physical.ts
+++ b/src/actions/monedex/wallets/update-wallet-physical.ts
@@ -60,6 +60,7 @@ export const updateWalletPhysical = async (data: UpdateWalletPhysical) => {
       wallet: updatedWallet
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error updating wallet physical amount:', error)
     return {
       ok: false,

--- a/src/components/diary/thought-form.tsx
+++ b/src/components/diary/thought-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { format } from 'date-fns'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import { FaRegSmile } from 'react-icons/fa'
@@ -73,6 +73,7 @@ const noticeSuccessSaved = () => {
 
 export const ThoughtForm = ({ thought, emotions }: ThoughtFormProps) => {
   const router = useRouter()
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const defaultValuesForm = {
@@ -86,6 +87,10 @@ export const ThoughtForm = ({ thought, emotions }: ThoughtFormProps) => {
     resolver: zodResolver(thoughtSchema),
     defaultValues: { ...defaultValuesForm }
   })
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
 
   const onSubmit = async (values: z.infer<typeof thoughtSchema>) => {
     setIsSubmitting(false)
@@ -137,7 +142,10 @@ export const ThoughtForm = ({ thought, emotions }: ThoughtFormProps) => {
                       <Textarea
                         className='pl-10 text-sm'
                         placeholder='Escribe aquí tu pensamiento'
-                        {...field}
+                        ref={(el) => {
+                          field.ref(el)
+                          textareaRef.current = el
+                        }}
                         value={field.value ?? ''}
                         disabled={isSubmitting}
                       />

--- a/src/components/monedex/budget/BudgetCategoryForm.tsx
+++ b/src/components/monedex/budget/BudgetCategoryForm.tsx
@@ -34,6 +34,7 @@ export function BudgetCategoryForm({ onSuccess }: BudgetCategoryFormProps) {
           setExpenseCategories(result.expenseCategories)
         }
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.error('Error loading expense categories:', error)
       }
     }

--- a/src/components/monedex/expenses/create-form.tsx
+++ b/src/components/monedex/expenses/create-form.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Calculator } from '@/components/ui/calculator'
 import { useState } from 'react'
 import { useFormState } from 'react-dom'
 import { BsCashStack } from 'react-icons/bs'
@@ -11,6 +9,8 @@ import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { ButtonBack } from '@/components/monedex/button-back'
 import { ButtonSaved } from '@/components/monedex/button-saved'
+import { Calculator } from '@/components/ui/calculator'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { type Category } from '@/interfaces/Category'
 import { createExpense } from '@/lib/actions'
 
@@ -26,7 +26,6 @@ export default function Form({
 
   const [amountValue, setAmountValue] = useState('')
   const [isCalculatorOpen, setIsCalculatorOpen] = useState(false)
-
 
   return (
     <form action={dispatch}>
@@ -80,12 +79,12 @@ export default function Form({
                   />
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0" align="start">
-                  <Calculator 
+                  <Calculator
                     initialValue={amountValue}
                     onResult={(val) => {
                       setAmountValue(val.toString())
                       setIsCalculatorOpen(false)
-                    }} 
+                    }}
                   />
                 </PopoverContent>
               </Popover>

--- a/src/components/monedex/expenses/create-form.tsx
+++ b/src/components/monedex/expenses/create-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { evaluate } from 'mathjs'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Calculator } from '@/components/ui/calculator'
 import { useState } from 'react'
 import { useFormState } from 'react-dom'
 import { BsCashStack } from 'react-icons/bs'
@@ -24,38 +25,8 @@ export default function Form({
   const currentDate = new Date().toISOString().split('T')[0]
 
   const [amountValue, setAmountValue] = useState('')
-  const [amountError, setAmountError] = useState<string | null>(null)
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false)
 
-  const evaluateExpression = (expression: string) => {
-    if (!expression.trim()) {
-      setAmountError(null)
-      return
-    }
-
-    try {
-      const result = evaluate(expression)
-
-      if (typeof result !== 'number' || isNaN(result) || !isFinite(result)) {
-        setAmountError('Expresión inválida')
-        return
-      }
-
-      const formattedResult = Number(result).toFixed(2)
-      setAmountValue(formattedResult)
-      setAmountError(null)
-    } catch (error) {
-      setAmountError('Expresión matemática incorrecta')
-    }
-  }
-
-  const handleAmountBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    evaluateExpression(e.target.value)
-  }
-
-  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setAmountValue(e.target.value)
-    setAmountError(null)
-  }
 
   return (
     <form action={dispatch}>
@@ -95,22 +66,33 @@ export default function Form({
           </label>
           <div className='relative mt-2 rounded-md'>
             <div className='relative'>
-              <input
-                id="amount"
-                name="amount"
-                type="text"
-                value={amountValue}
-                onChange={handleAmountChange}
-                onBlur={handleAmountBlur}
-                placeholder="Ingresa la cantidad o expresión (ej: 23+2/5)"
-                className="peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500"
-                aria-describedby="amount-error"
-              />
-              <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900' />
+              <Popover open={isCalculatorOpen} onOpenChange={setIsCalculatorOpen}>
+                <PopoverTrigger asChild>
+                  <input
+                    id="amount"
+                    name="amount"
+                    type="text"
+                    readOnly
+                    value={amountValue}
+                    placeholder="Ingresa la cantidad"
+                    className="peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 cursor-pointer bg-white"
+                    aria-describedby="amount-error"
+                  />
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calculator 
+                    initialValue={amountValue}
+                    onResult={(val) => {
+                      setAmountValue(val.toString())
+                      setIsCalculatorOpen(false)
+                    }} 
+                  />
+                </PopoverContent>
+              </Popover>
+              <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 z-10' />
             </div>
           </div>
           <div id='amount-error' aria-live='polite' aria-atomic='true'>
-            {amountError && <p className="mt-2 text-sm text-red-500">{amountError}</p>}
             {state.errors &&
               state.errors.amount &&
               state.errors.amount.map((error: string) => (

--- a/src/components/monedex/expenses/edit-form.tsx
+++ b/src/components/monedex/expenses/edit-form.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Calculator } from '@/components/ui/calculator'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useFormState } from 'react-dom'
@@ -12,6 +10,8 @@ import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { ButtonBack } from '@/components/monedex/button-back'
 import { ButtonSaved } from '@/components/monedex/button-saved'
+import { Calculator } from '@/components/ui/calculator'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { type Category } from '@/interfaces/Category'
 import { type ExpenseForm } from '@/interfaces/Expense'
 import { updateExpense } from '@/lib/actions'
@@ -38,7 +38,6 @@ export default function EditExpenseForm({
       router.back()
     }
   }, [state])
-
 
   return (
     <form action={dispatch}>
@@ -92,12 +91,12 @@ export default function EditExpenseForm({
                   />
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0" align="start">
-                  <Calculator 
+                  <Calculator
                     initialValue={amountValue}
                     onResult={(val) => {
                       setAmountValue(val.toString())
                       setIsCalculatorOpen(false)
-                    }} 
+                    }}
                   />
                 </PopoverContent>
               </Popover>

--- a/src/components/monedex/expenses/edit-form.tsx
+++ b/src/components/monedex/expenses/edit-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { evaluate } from 'mathjs'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Calculator } from '@/components/ui/calculator'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useFormState } from 'react-dom'
@@ -30,7 +31,7 @@ export default function EditExpenseForm({
   const [state, dispatch] = useFormState(updateExpenseWithId, initialState)
 
   const [amountValue, setAmountValue] = useState(expense.amount.toString())
-  const [amountError, setAmountError] = useState<string | null>(null)
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false)
 
   useEffect(() => {
     if (state.message === 'Updated expense') {
@@ -38,36 +39,6 @@ export default function EditExpenseForm({
     }
   }, [state])
 
-  const evaluateExpression = (expression: string) => {
-    if (!expression.trim()) {
-      setAmountError(null)
-      return
-    }
-
-    try {
-      const result = evaluate(expression)
-
-      if (typeof result !== 'number' || isNaN(result) || !isFinite(result)) {
-        setAmountError('Expresión inválida')
-        return
-      }
-
-      const formattedResult = Number(result).toFixed(2)
-      setAmountValue(formattedResult)
-      setAmountError(null)
-    } catch (error) {
-      setAmountError('Expresión matemática incorrecta')
-    }
-  }
-
-  const handleAmountBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    evaluateExpression(e.target.value)
-  }
-
-  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setAmountValue(e.target.value)
-    setAmountError(null)
-  }
 
   return (
     <form action={dispatch}>
@@ -107,22 +78,33 @@ export default function EditExpenseForm({
           </label>
           <div className='relative mt-2 rounded-md'>
             <div className='relative'>
-              <input
-                id='amount'
-                name='amount'
-                type='text'
-                placeholder='Ingresa la cantidad o expresión (ej: 23+2/5)'
-                className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500'
-                aria-describedby='amount-error'
-                value={amountValue}
-                onChange={handleAmountChange}
-                onBlur={handleAmountBlur}
-              />
-              <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900' />
+              <Popover open={isCalculatorOpen} onOpenChange={setIsCalculatorOpen}>
+                <PopoverTrigger asChild>
+                  <input
+                    id='amount'
+                    name='amount'
+                    type='text'
+                    readOnly
+                    placeholder='Ingresa la cantidad'
+                    className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 cursor-pointer bg-white'
+                    aria-describedby='amount-error'
+                    value={amountValue}
+                  />
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calculator 
+                    initialValue={amountValue}
+                    onResult={(val) => {
+                      setAmountValue(val.toString())
+                      setIsCalculatorOpen(false)
+                    }} 
+                  />
+                </PopoverContent>
+              </Popover>
+              <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 z-10' />
             </div>
           </div>
           <div id='amount-error' aria-live='polite' aria-atomic='true'>
-            {amountError && <p className="mt-2 text-sm text-red-500">{amountError}</p>}
             {state?.errors?.amount?.map((error: string) => (
               <p className='mt-2 text-sm text-red-500' key={`amount:${error}`}>
                 {error}

--- a/src/components/monedex/incomes/income-form.tsx
+++ b/src/components/monedex/incomes/income-form.tsx
@@ -22,6 +22,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/componen
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Calculator } from '@/components/ui/calculator'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { type Income, type IncomeCategory } from '@/interfaces/income.interface'
@@ -90,6 +91,7 @@ const noticeSuccessSaved = () => {
 export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isCalculatorAmountOpen, setIsCalculatorAmountOpen] = useState(false)
 
   const defaultValuesForm = {
     id: income?.id ? Number(income.id) : undefined,
@@ -181,16 +183,30 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
                   </FormLabel>
                   <FormControl>
                     <div className='relative rounded-md'>
-                      <Input
-                        className='pl-10 text-sm bg-monedex-light'
-                        placeholder='Ingresa la cantidad'
-                        step='0.01'
-                        {...field}
-                        value={field.value}
-                        type='number'
-                        disabled={isSubmitting}
-                      />
-                      <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900' />
+                      <Popover open={isCalculatorAmountOpen} onOpenChange={setIsCalculatorAmountOpen}>
+                        <PopoverTrigger asChild>
+                          <Input
+                            className='pl-10 text-sm bg-monedex-light cursor-pointer'
+                            placeholder='Ingresa la cantidad'
+                            {...field}
+                            value={field.value ?? ''}
+                            type='text'
+                            readOnly
+                            disabled={isSubmitting}
+                          />
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                          <Calculator 
+                            initialValue={field.value?.toString() ?? ''}
+                            onResult={(val) => {
+                              form.setValue('amount', val)
+                              form.trigger('amount')
+                              setIsCalculatorAmountOpen(false)
+                            }} 
+                          />
+                        </PopoverContent>
+                      </Popover>
+                      <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 z-10' />
                     </div>
                   </FormControl>
                   <FormMessage />

--- a/src/components/monedex/incomes/income-form.tsx
+++ b/src/components/monedex/incomes/income-form.tsx
@@ -17,12 +17,12 @@ import { createUpdateIncome } from '@/actions/monedex/incomes/create-update-inco
 import { ButtonBack } from '@/components/monedex/button-back'
 import { ButtonSaved } from '@/components/monedex/button-saved'
 import { Button } from '@/components/ui/button'
+import { Calculator } from '@/components/ui/calculator'
 import { Calendar } from '@/components/ui/calendar'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Calculator } from '@/components/ui/calculator'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { type Income, type IncomeCategory } from '@/interfaces/income.interface'
@@ -196,13 +196,13 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
                           />
                         </PopoverTrigger>
                         <PopoverContent className="w-auto p-0" align="start">
-                          <Calculator 
+                          <Calculator
                             initialValue={field.value?.toString() ?? ''}
                             onResult={(val) => {
                               form.setValue('amount', val)
                               form.trigger('amount')
                               setIsCalculatorAmountOpen(false)
-                            }} 
+                            }}
                           />
                         </PopoverContent>
                       </Popover>

--- a/src/components/monedex/wallets/physical-amount-modal.tsx
+++ b/src/components/monedex/wallets/physical-amount-modal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { evaluate } from 'mathjs'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Calculator } from '@/components/ui/calculator'
 import { useState, useEffect } from 'react'
 import toast from 'react-hot-toast'
 import { IoWalletOutline } from 'react-icons/io5'
@@ -39,7 +40,7 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
   const [walletsLocal, setWalletsLocal] = useState<PhysicalAmountModalProps['wallets']>([])
   const [selectedWalletId, setSelectedWalletId] = useState<string>('')
   const [physicalAmount, setPhysicalAmount] = useState<string>('')
-  const [amountError, setAmountError] = useState<string | null>(null)
+  const [isCalculatorOpen, setIsCalculatorOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
 
   // Fetch wallets when modal opens
@@ -57,36 +58,6 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
     }
   }
 
-  const evaluateExpression = (expression: string) => {
-    if (!expression.trim()) {
-      setAmountError(null)
-      return
-    }
-
-    try {
-      const result = evaluate(expression)
-
-      if (typeof result !== 'number' || isNaN(result) || !isFinite(result)) {
-        setAmountError('Expresión inválida')
-        return
-      }
-
-      const formattedResult = Number(result).toFixed(2)
-      setPhysicalAmount(formattedResult)
-      setAmountError(null)
-    } catch (error) {
-      setAmountError('Expresión matemática incorrecta')
-    }
-  }
-
-  const handleAmountBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    evaluateExpression(e.target.value)
-  }
-
-  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPhysicalAmount(e.target.value)
-    setAmountError(null)
-  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -135,7 +106,6 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
       // Reset form when closing
       setSelectedWalletId('')
       setPhysicalAmount('')
-      setAmountError(null)
     }
   }
 
@@ -185,17 +155,27 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
                 Physical Amount
               </Label>
               <div className="col-span-4">
-                <Input
-                  id="physicalAmount"
-                  type="text"
-                  placeholder="Ingresa la cantidad o expresión (ej: 23+2/5)"
-                  value={physicalAmount}
-                  onChange={handleAmountChange}
-                  onBlur={handleAmountBlur}
-                />
-                {amountError && (
-                  <p className="text-sm text-red-500 mt-1">{amountError}</p>
-                )}
+                <Popover open={isCalculatorOpen} onOpenChange={setIsCalculatorOpen}>
+                  <PopoverTrigger asChild>
+                    <Input
+                      id="physicalAmount"
+                      type="text"
+                      readOnly
+                      placeholder="Ingresa la cantidad"
+                      value={physicalAmount}
+                      className="cursor-pointer"
+                    />
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calculator 
+                      initialValue={physicalAmount}
+                      onResult={(val) => {
+                        setPhysicalAmount(val.toString())
+                        setIsCalculatorOpen(false)
+                      }} 
+                    />
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
           </div>

--- a/src/components/monedex/wallets/physical-amount-modal.tsx
+++ b/src/components/monedex/wallets/physical-amount-modal.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Calculator } from '@/components/ui/calculator'
 import { useState, useEffect } from 'react'
 import toast from 'react-hot-toast'
 import { IoWalletOutline } from 'react-icons/io5'
 import { updateWalletPhysical } from '@/actions/monedex/wallets/update-wallet-physical'
 import { Button } from '@/components/ui/button'
+import { Calculator } from '@/components/ui/calculator'
 import {
   Dialog,
   DialogContent,
@@ -18,6 +17,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
   Select,
   SelectContent,
@@ -57,7 +57,6 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
       toast.error('Error loading wallets')
     }
   }
-
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -167,12 +166,12 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
                     />
                   </PopoverTrigger>
                   <PopoverContent className="w-auto p-0" align="start">
-                    <Calculator 
+                    <Calculator
                       initialValue={physicalAmount}
                       onResult={(val) => {
                         setPhysicalAmount(val.toString())
                         setIsCalculatorOpen(false)
-                      }} 
+                      }}
                     />
                   </PopoverContent>
                 </Popover>

--- a/src/components/ui/calculator.tsx
+++ b/src/components/ui/calculator.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
-import { evaluate } from 'mathjs'
-import { Button } from '@/components/ui/button'
 import { Delete } from 'lucide-react'
+import { evaluate } from 'mathjs'
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
 
 interface CalculatorProps {
   onResult: (value: number) => void
@@ -54,7 +54,7 @@ export function Calculator({ onResult, initialValue }: CalculatorProps) {
     try {
       const sanitizedExpression = expression.replace(/×/g, '*').replace(/÷/g, '/')
       const result = evaluate(sanitizedExpression)
-      if (typeof result === 'number' && isNaN(result) === false && isFinite(result)) {
+      if (typeof result === 'number' && !isNaN(result) && isFinite(result)) {
         const resultString = Number(result.toFixed(2)).toString()
         setExpression(resultString)
         onResult(Number(resultString))
@@ -84,26 +84,26 @@ export function Calculator({ onResult, initialValue }: CalculatorProps) {
         <Button variant='outline' className={actionBtnClass} onClick={handleBackspace}>
           <Delete className='w-5 h-5' />
         </Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('÷')}>÷</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('×')}>×</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('÷') }}>÷</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('×') }}>×</Button>
 
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('7')}>7</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('8')}>8</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('9')}>9</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('-')}>-</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('7') }}>7</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('8') }}>8</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('9') }}>9</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('-') }}>-</Button>
 
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('4')}>4</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('5')}>5</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('6')}>6</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('+')}>+</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('4') }}>4</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('5') }}>5</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('6') }}>6</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('+') }}>+</Button>
 
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('1')}>1</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('2')}>2</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('3')}>3</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('1') }}>1</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('2') }}>2</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('3') }}>3</Button>
         <Button variant='default' className={`${accentBtnClass} row-span-2 h-full`} onClick={handleEqual}>=</Button>
 
-        <Button variant='outline' className={`${btnClass} col-span-2`} onClick={() => handlePress('0')}>0</Button>
-        <Button variant='outline' className={btnClass} onClick={() => handlePress('.')}>.</Button>
+        <Button variant='outline' className={`${btnClass} col-span-2`} onClick={() => { handlePress('0') }}>0</Button>
+        <Button variant='outline' className={btnClass} onClick={() => { handlePress('.') }}>.</Button>
       </div>
     </div>
   )

--- a/src/components/ui/calculator.tsx
+++ b/src/components/ui/calculator.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { evaluate } from 'mathjs'
+import { Button } from '@/components/ui/button'
+import { Delete } from 'lucide-react'
+
+interface CalculatorProps {
+  onResult: (value: number) => void
+  initialValue?: string
+}
+
+export function Calculator({ onResult, initialValue }: CalculatorProps) {
+  const [expression, setExpression] = useState(initialValue && initialValue !== '' ? initialValue : '0')
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (initialValue && initialValue !== '') {
+      setExpression(initialValue)
+    } else {
+      setExpression('0')
+    }
+  }, [initialValue])
+
+  const handlePress = (val: string) => {
+    if (error) {
+      setExpression(val)
+      setError(false)
+      return
+    }
+    setExpression((prev) => {
+      if (prev === '0' && val !== '.') {
+        return val
+      }
+      if (prev.length > 20) return prev
+      return prev + val
+    })
+  }
+
+  const handleClear = () => {
+    setExpression('0')
+    setError(false)
+  }
+
+  const handleBackspace = () => {
+    if (error) {
+      handleClear()
+      return
+    }
+    setExpression((prev) => (prev.length > 1 ? prev.slice(0, -1) : '0'))
+  }
+
+  const handleEqual = () => {
+    try {
+      const sanitizedExpression = expression.replace(/×/g, '*').replace(/÷/g, '/')
+      const result = evaluate(sanitizedExpression)
+      if (typeof result === 'number' && isNaN(result) === false && isFinite(result)) {
+        const resultString = Number(result.toFixed(2)).toString()
+        setExpression(resultString)
+        onResult(Number(resultString))
+        setError(false)
+      } else {
+        setError(true)
+      }
+    } catch (e) {
+      setError(true)
+    }
+  }
+
+  const btnClass = 'text-lg font-medium py-6'
+  const actionBtnClass = 'text-lg font-medium py-6 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-100 hover:bg-slate-200 dark:hover:bg-slate-700'
+  const accentBtnClass = 'text-lg font-medium py-6 bg-blue-500 hover:bg-blue-600 text-white'
+
+  return (
+    <div className='w-full max-w-sm mx-auto p-4 bg-white dark:bg-slate-950 rounded-xl shadow-sm border border-slate-200 dark:border-slate-800'>
+      <div className='mb-4 p-4 text-right bg-slate-50 dark:bg-slate-900 rounded-lg min-h-[80px] flex flex-col justify-center overflow-x-auto border border-slate-100 dark:border-slate-800'>
+        <div className={`text-3xl font-semibold tracking-tight ${error ? 'text-red-500' : 'text-slate-900 dark:text-slate-50'}`}>
+          {error ? 'Error' : expression}
+        </div>
+      </div>
+
+      <div className='grid grid-cols-4 gap-2'>
+        <Button variant='outline' className={actionBtnClass} onClick={handleClear}>C</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={handleBackspace}>
+          <Delete className='w-5 h-5' />
+        </Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('÷')}>÷</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('×')}>×</Button>
+
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('7')}>7</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('8')}>8</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('9')}>9</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('-')}>-</Button>
+
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('4')}>4</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('5')}>5</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('6')}>6</Button>
+        <Button variant='outline' className={actionBtnClass} onClick={() => handlePress('+')}>+</Button>
+
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('1')}>1</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('2')}>2</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('3')}>3</Button>
+        <Button variant='default' className={`${accentBtnClass} row-span-2 h-full`} onClick={handleEqual}>=</Button>
+
+        <Button variant='outline' className={`${btnClass} col-span-2`} onClick={() => handlePress('0')}>0</Button>
+        <Button variant='outline' className={btnClass} onClick={() => handlePress('.')}>.</Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 🧮 Add calculator for amount inputs

### Summary
This PR introduces a reusable **Calculator component** to handle monetary inputs across Monedex forms. Instead of typing numbers or expressions directly, users can now open a calculator popover and insert the result into the field.

### Changes
- Added `Calculator` component integrated with `Popover`.
- Enabled calculator input for:
  - Expense create form
  - Expense edit form
  - Income form
  - Physical wallet amount modal
- Removed previous expression parsing logic using `mathjs`.
- Simplified amount state handling in forms.

### Other Improvements
- Minor lint and formatting cleanup.
- Reordered imports and normalized handlers.
- Allowed intentional `console.error` logging with ESLint rule overrides.

### Impact
Improves UX when entering monetary amounts and centralizes calculation logic in a reusable component.