### PR TITLE
fix: 🐛 avoid ref override in thought textarea

### DIFF
--- a/src/components/diary/thought-form.tsx
+++ b/src/components/diary/thought-form.tsx
@@ -140,6 +140,7 @@ export const ThoughtForm = ({ thought, emotions }: ThoughtFormProps) => {
                   <FormControl>
                     <div className='relative'>
                       <Textarea
+                        {...field}
                         className='pl-10 text-sm'
                         placeholder='Escribe aquí tu pensamiento'
                         ref={(el) => {


### PR DESCRIPTION
### Changes Made
- fix: 🐛 spread field props into Textarea
- fix: 🐛 prevent ref overwrite warning

### Description of Changes
- Fixed a React warning where `ref` was being specified more than once in the `Textarea` component inside `ThoughtForm`.
- Added `{...field}` to correctly spread React Hook Form properties into the component, ensuring proper form registration and state handling.
- This change prevents the `ref` overwrite issue and ensures the textarea works correctly with the form control system while maintaining the custom ref logic already present.