### PR TITLE
feat: 📅 store income month for budgeting logic

### DIFF
--- a/src/actions/monedex/incomes/create-update-income.ts
+++ b/src/actions/monedex/incomes/create-update-income.ts
@@ -156,6 +156,7 @@ export const createUpdateIncome = async (formData: FormData) => {
             amount,
             income_category_id: Number(incomeCategoryId),
             income_date: incomeDate,
+            income_month: incomeDate.getMonth() + 1,
             method,
             wallet_id: newWallet.id // Relation to the new wallet
           }
@@ -182,6 +183,7 @@ export const createUpdateIncome = async (formData: FormData) => {
           amount,
           income_category_id: Number(incomeCategoryId),
           income_date: incomeDate,
+          income_month: incomeDate.getMonth() + 1,
           method
         }
       })

--- a/src/components/monedex/budget/BudgetModal.tsx
+++ b/src/components/monedex/budget/BudgetModal.tsx
@@ -40,8 +40,8 @@ export function BudgetModal({ open, onOpenChange }: BudgetModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px] text-start">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader className='text-start'>
           <DialogTitle>Crear nueva categoría de presupuesto</DialogTitle>
           <DialogDescription>
             Agregue una nueva categoría para organizar sus presupuestos mensuales.

--- a/src/components/monedex/selectable-expense-cards.tsx
+++ b/src/components/monedex/selectable-expense-cards.tsx
@@ -97,10 +97,6 @@ export default function SelectableExpenseCards({ expenses }: { expenses: Expense
                 <p className="font-medium">{formatWithRelation(expense.with_relation)}</p>
               </div>
 
-              <div className="flex w-1/2 flex-col">
-                <p className="text-xs">Lugar</p>
-                <p className="font-medium">{expense.place.name}</p>
-              </div>
             </div>
 
             <div className="py-2">Creado por {expense.user.name}</div>


### PR DESCRIPTION
### Changes Made
- feat: 📅 add income_month to income creation
- feat: 📅 add income_month to income update
- style: 🎨 move text-start to DialogHeader
- refactor: ♻️ remove unused place field in expense cards

### Description of Changes
- Added the `income_month` field when creating and updating incomes. The value is derived from `incomeDate.getMonth() + 1` to store the numeric month of the income. This enables easier monthly grouping and filtering for budgeting logic without recalculating the month from the date.
- Adjusted the `BudgetModal` layout by moving the `text-start` class from `DialogContent` to `DialogHeader` to better align the title and description styling.
- Removed the unused `place` display block from `SelectableExpenseCards`, simplifying the UI and preventing unnecessary rendering of location information that is no longer required.