### PR TITLE
feat: 🔐 add admin-based UI access control

### DIFF
--- a/src/app/monedex/dashboard/page.tsx
+++ b/src/app/monedex/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { getUserSessionServer } from '@/actions'
 import { getAllWalletsSummary } from '@/actions/monedex/wallets/get-all-wallet-summary'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import { MetricCard } from '@/components/monedex/wallets/MetricCard'
@@ -12,6 +13,9 @@ export default async function DashboardPage(props: {
   const currentYear = new Date().getFullYear()
   const month = Number(searchParams.month) || Number(currentMonth)
   const year = Number(searchParams.year) || currentYear
+
+  const user = await getUserSessionServer()
+  const isAdmin = user?.role === 'admin'
 
   const { walletsSummary, globalSummary } = await getAllWalletsSummary({ month, year })
 
@@ -38,10 +42,12 @@ export default async function DashboardPage(props: {
           <FilterMonth /> */}
         {/* </div> */}
 
-        {/* Physical Amount Modal Trigger */}
-        <div>
-          <PhysicalAmountModal wallets={wallets} />
-        </div>
+        {/* Physical Amount Modal Trigger - Admin only */}
+        {isAdmin && (
+          <div>
+            <PhysicalAmountModal wallets={wallets} />
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col md:grid md:grid-cols-2 gap-4 ">

--- a/src/app/monedex/expenses/page.tsx
+++ b/src/app/monedex/expenses/page.tsx
@@ -1,5 +1,6 @@
 import { type Metadata } from 'next'
 import { Suspense } from 'react'
+import { getUserSessionServer } from '@/actions'
 
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import { CreateExpense } from '@/components/monedex/expenses/buttons'
@@ -28,6 +29,9 @@ export default async function ExpensesPage(props: {
 
   const currentPage = Number(searchParams?.page) || 1
 
+  const user = await getUserSessionServer()
+  const isAdmin = user?.role === 'admin'
+
   const totalPages = await fetchExpensesPages(query, Number(month), Number(year))
 
   return (
@@ -51,7 +55,7 @@ export default async function ExpensesPage(props: {
       <div className='flex flex-col gap-2'>
 
         <Suspense key={`${query}${currentPage}`} fallback='Loading'>
-          <ExpensesTable query={query} currentPage={currentPage} month={month} year={year} />
+          <ExpensesTable query={query} currentPage={currentPage} month={month} year={year} isAdmin={isAdmin} />
         </Suspense>
 
         <div className="mt-5 flex w-full justify-center">

--- a/src/app/monedex/incomes/page.tsx
+++ b/src/app/monedex/incomes/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from 'next'
+import { getUserSessionServer } from '@/actions'
 import { fetchTotalIcomesPages } from '@/actions/monedex/incomes/fetch-total-incomes-pages'
 import { getIncomeByCategory } from '@/actions/monedex/incomes/get-income-by-category'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
@@ -27,6 +28,9 @@ export default async function IncomesPage(props: {
 
   const currentPage = Number(searchParams?.page) || 1
 
+  const user = await getUserSessionServer()
+  const isAdmin = user?.role === 'admin'
+
   const totalPages = await fetchTotalIcomesPages(query, Number(month), Number(year))
   const { incomeByCategory, totalIncome } = await getIncomeByCategory(Number(month), Number(year))
 
@@ -51,7 +55,7 @@ export default async function IncomesPage(props: {
 
       <div className='flex flex-col gap-2 pt-5'>
 
-        <IncomesTable query={query} currentPage={currentPage} month={month} year={year} />
+        <IncomesTable query={query} currentPage={currentPage} month={month} year={year} isAdmin={isAdmin} />
 
         <div className="mt-5 flex w-full justify-center">
           <Pagination totalPages={totalPages} />

--- a/src/components/monedex/expenses/table.tsx
+++ b/src/components/monedex/expenses/table.tsx
@@ -1,3 +1,4 @@
+import { DeleteExpense } from './buttons'
 import SelectableExpenseCards from '@/components/monedex/selectable-expense-cards'
 import { fetchFilteredExpenses } from '@/lib/data'
 import { formatDateToLocal } from '@/lib/helpers'
@@ -6,12 +7,14 @@ export default async function ExpensesTable({
   query,
   currentPage,
   month,
-  year
+  year,
+  isAdmin
 }: {
   query: string
   month: number
   year?: number
   currentPage: number
+  isAdmin?: boolean
 }): Promise<JSX.Element> {
   const currentYear = year || new Date().getFullYear()
 
@@ -32,7 +35,7 @@ export default async function ExpensesTable({
           <div className='inline-block min-w-full align-middle'>
             <div className='overflow-hidden rounded-md bg-gray-50 p-2 md:pt-0'>
               <div className='md:hidden'>
-                <SelectableExpenseCards expenses={expenses} />
+                <SelectableExpenseCards expenses={expenses} isAdmin={isAdmin} />
               </div>
               <table className='hidden min-w-full rounded-md text-gray-900 md:table'>
                 <thead className='rounded-md bg-gray-50 text-left text-sm font-normal'>
@@ -80,9 +83,8 @@ export default async function ExpensesTable({
                       </td>
                       <td>
                         <div className='flex justify-end gap-2'>
-                          {/* <UpdateCustomer id={customer.id} />
-                        <DeleteCustomer id={customer.id} /> */}
-                        </div>b
+                          {isAdmin && <DeleteExpense id={expense.id} />}
+                        </div>
                       </td>
                     </tr>
                   ))}

--- a/src/components/monedex/incomes/income-table.tsx
+++ b/src/components/monedex/incomes/income-table.tsx
@@ -7,12 +7,14 @@ export default async function IncomesTable({
   query,
   currentPage,
   month,
-  year
+  year,
+  isAdmin
 }: {
   query: string
   month: number
   year?: number
   currentPage: number
+  isAdmin?: boolean
 }): Promise<JSX.Element> {
   const currentYear = year || new Date().getFullYear()
 
@@ -48,7 +50,7 @@ export default async function IncomesTable({
                       {/*  buttons delete - update */}
                       <div className='flex justify-end gap-2'>
                         <UpdateIncome id={income.id} />
-                        <DeleteIncome id={income.id} />
+                        {isAdmin && <DeleteIncome id={income.id} />}
                       </div>
                     </div>
                     {/* body card */}
@@ -125,8 +127,7 @@ export default async function IncomesTable({
                       </td>
                       <td>
                         <div className='flex justify-end gap-2'>
-                          {/* <UpdateCustomer id={customer.id} />
-                        <DeleteCustomer id={customer.id} /> */}
+                          {isAdmin && <DeleteIncome id={income.id} />}
                         </div>
                       </td>
                     </tr>

--- a/src/components/monedex/selectable-expense-cards.tsx
+++ b/src/components/monedex/selectable-expense-cards.tsx
@@ -6,7 +6,7 @@ import { DeleteExpense, ReconciledExpense, UpdateExpense } from '@/components/mo
 import { type ExpenseWithCategoryAndUserAndPlace } from '@/interfaces/Expense'
 import { formatCurrency, formatMethod, formatWithRelation } from '@/lib/helpers'
 
-export default function SelectableExpenseCards({ expenses }: { expenses: ExpenseWithCategoryAndUserAndPlace[] }) {
+export default function SelectableExpenseCards({ expenses, isAdmin }: { expenses: ExpenseWithCategoryAndUserAndPlace[], isAdmin?: boolean }) {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
 
   const toggleSelection = (id: number) => {
@@ -71,7 +71,7 @@ export default function SelectableExpenseCards({ expenses }: { expenses: Expense
               <div className="flex justify-end gap-2" onClick={(e) => { e.stopPropagation() }}>
                 <ReconciledExpense id={expense.id} reconciled={expense.is_reconciled} />
                 <UpdateExpense id={expense.id} />
-                <DeleteExpense id={expense.id} />
+                {isAdmin && <DeleteExpense id={expense.id} />}
               </div>
             </div>
 


### PR DESCRIPTION
### Changes Made
- feat: 🔐 fetch user session on server pages
- feat: 🔐 derive isAdmin flag from user role
- feat: 🔐 restrict PhysicalAmountModal to admins
- feat: 🔐 pass isAdmin prop to tables
- feat: 🔐 conditionally render delete actions
- refactor: ♻️ extend components with isAdmin prop

### Description of Changes
- Implemented role-based UI control by retrieving the user session on server-side pages and deriving an `isAdmin` flag from the user role.
- Restricted sensitive actions (such as deleting expenses/incomes and accessing the Physical Amount modal) to admin users only.
- Propagated the `isAdmin` flag down to relevant components (`ExpensesTable`, `IncomesTable`, and `SelectableExpenseCards`) to centralize permission handling.
- Updated UI components to conditionally render delete actions based on admin privileges, preventing unauthorized interactions at the interface level.
- This improves security and ensures that only authorized users can perform destructive or sensitive operations.