### PR TITLE
refactor: 🔄 replace hardcoded wallet type selectors with dynamic wall…

### DIFF
--- a/src/actions/monedex/incomes/create-update-income.ts
+++ b/src/actions/monedex/incomes/create-update-income.ts
@@ -8,41 +8,31 @@ import prisma from '@/lib/prisma'
 const incomeSchema = z.object({
   id: z.number().optional().nullable(),
   name: z
-    .string({
-      required_error: 'El nombre es requerido.'
-    })
-    .min(3, {
-      message: 'El nombre debe tener al menos 3 caracteres.'
-    })
-    .max(100, {
-      message: 'El nombre debe tener máximo 100 caracteres.'
-    }),
+    .string({ required_error: 'El nombre es requerido.' })
+    .min(3, { message: 'El nombre debe tener al menos 3 caracteres.' })
+    .max(100, { message: 'El nombre debe tener máximo 100 caracteres.' }),
   amount: z
     .coerce.number({
       required_error: 'La cantidad es requerida.',
       invalid_type_error: 'La cantidad es requerida.'
-    }).gt(0, {
-      message: 'Por favor ingrese una cantidad mayor que $0.'
-    }),
-  method: z
-    .enum(['debit', 'cash'], {
-      required_error: 'El método de ingreso es requerido.'
-    }),
+    }).gt(0, { message: 'Por favor ingrese una cantidad mayor que $0.' }),
+  // walletId replaces the old method enum — the user now selects a specific wallet
+  walletId: z
+    .coerce.number({
+      required_error: 'La cartera es requerida.',
+      invalid_type_error: 'Selecciona una cartera válida.'
+    })
+    .int()
+    .min(1, { message: 'Selecciona una cartera.' }),
   incomeDate: z
     .date({
       required_error: 'La fecha del ingreso es requerida',
       invalid_type_error: 'Por favor ingresa una fecha valida.'
     }),
   incomeCategoryId: z
-    .number({
-      required_error: 'La categoría del ingreso es requerida.'
-    })
-    .int({
-      message: 'La categoría del ingreso debe ser un número entero.'
-    })
-    .min(1, {
-      message: 'La categoría del ingreso debe ser mayor o igual a 1.'
-    })
+    .number({ required_error: 'La categoría del ingreso es requerida.' })
+    .int({ message: 'La categoría del ingreso debe ser un número entero.' })
+    .min(1, { message: 'La categoría del ingreso debe ser mayor o igual a 1.' })
 })
 
 const messages = {
@@ -57,6 +47,7 @@ export const createUpdateIncome = async (formData: FormData) => {
   const dataToValidate = {
     ...data,
     id: data.id ? Number(data.id) : undefined,
+    walletId: data.walletId ? Number(data.walletId) : undefined,
     incomeCategoryId: data.incomeCategoryId ? Number(data.incomeCategoryId) : undefined,
     incomeDate: data.incomeDate ? new Date(String(data.incomeDate)) : undefined
   }
@@ -70,82 +61,53 @@ export const createUpdateIncome = async (formData: FormData) => {
     }
   }
 
-  // check user
+  // Verify the user session
   const userSession = await getUserSessionServer()
   const email = userSession?.email
-  const user = await prisma.user.findFirst({
-    where: {
-      email
-    }
-  })
+  const user = await prisma.user.findFirst({ where: { email } })
 
   if (user === null) {
-    return {
-      message: 'Credentials no valid'
-    }
+    return { ok: false, message: 'Credentials not valid' }
   }
 
-  const { amount, incomeCategoryId, incomeDate, method, name, id } = incomeParsed.data
+  const { amount, incomeCategoryId, incomeDate, walletId, name, id } = incomeParsed.data
 
   try {
-    const wallet = await prisma.wallet.findFirst({
-      where: {
-        type: method
-      },
-      select: {
-        id: true,
-        balance: true
-      }
+    // Fetch the selected wallet by its exact id — no longer looking up by type
+    const wallet = await prisma.wallet.findUnique({
+      where: { id: walletId },
+      select: { id: true, balance: true, type: true }
     })
 
     if (!wallet) {
-      return {
-        ok: false,
-        message: 'Wallet not found'
-      }
+      return { ok: false, message: 'Wallet not found' }
     }
 
-    // Update income
+    // Derive the method string from the wallet type (stored for reporting purposes)
+    const method = wallet.type
+
+    // Update existing income
     if (id) {
       const oldIncome = await prisma.income.findFirst({
         where: { id },
-        select: {
-          amount: true,
-          wallet_id: true,
-          method: true
-        }
+        select: { amount: true, wallet_id: true }
       })
 
       if (!oldIncome) {
-        return { message: 'Ingreso no encontrado.' }
-      }
-      // Get the new wallet according to the new method
-      const newWallet = await prisma.wallet.findFirst({
-        where: {
-          type: method
-        },
-        select: {
-          id: true
-        }
-      })
-
-      if (!newWallet) {
-        return {
-          message: 'Billetera no encontrada, cree una billetera primero.'
-        }
+        return { ok: false, message: 'Ingreso no encontrado.' }
       }
 
-      // If the method has changed, we need to update the balance of the old wallet
-      if (oldIncome.method !== method) { // method has changed
-        // Update the old wallet balance
+      // If the wallet changed, reverse the old wallet balance and apply to the new one
+      if (oldIncome.wallet_id !== walletId) {
+        // Reverse the income from the previous wallet
         await prisma.wallet.update({
           where: { id: oldIncome.wallet_id },
           data: { balance: { decrement: oldIncome.amount } }
         })
 
-        // Update the new wallet balance
+        // Apply the new amount to the selected wallet
         await prisma.wallet.update({
-          where: { id: newWallet.id },
+          where: { id: walletId },
           data: { balance: { increment: amount } }
         })
 
@@ -158,22 +120,20 @@ export const createUpdateIncome = async (formData: FormData) => {
             income_date: incomeDate,
             income_month: incomeDate.getMonth() + 1,
             method,
-            wallet_id: newWallet.id // Relation to the new wallet
+            wallet_id: walletId
           }
         })
 
         revalidatePath(`/monedex/incomes/${id}`)
-
-        return { message: 'Updated income' }
+        return { ok: true, message: messages.incomeUpdateSuccess }
       }
 
-      // If the method has not changed, we need to update the balance of the wallet
-      const newBalance = amount - oldIncome.amount // Wallet balance updated
+      // Same wallet — adjust the balance by the difference
+      const balanceDiff = amount - oldIncome.amount
 
-      // Update the balance of the old wallet
       await prisma.wallet.update({
         where: { id: oldIncome.wallet_id },
-        data: { balance: { increment: newBalance } }
+        data: { balance: { increment: balanceDiff } }
       })
 
       await prisma.income.update({
@@ -189,20 +149,16 @@ export const createUpdateIncome = async (formData: FormData) => {
       })
 
       revalidatePath(`/monedex/incomes/${id}`)
-
-      return {
-        ok: true,
-        message: messages.incomeUpdateSuccess
-      }
+      return { ok: true, message: messages.incomeUpdateSuccess }
     }
 
-    // Create income
+    // Create new income
     const income = await prisma.income.create({
       data: {
         name,
         amount,
         method,
-        wallet_id: wallet.id,
+        wallet_id: walletId,
         income_date: incomeDate,
         income_month: incomeDate.getMonth() + 1,
         income_category_id: incomeCategoryId,
@@ -210,16 +166,10 @@ export const createUpdateIncome = async (formData: FormData) => {
       }
     })
 
-    // update wallet balance
+    // Increment the wallet balance
     await prisma.wallet.update({
-      where: {
-        id: wallet.id
-      },
-      data: {
-        balance: {
-          increment: amount
-        }
-      }
+      where: { id: walletId },
+      data: { balance: { increment: amount } }
     })
 
     revalidatePath('/monedex/incomes/')
@@ -229,10 +179,7 @@ export const createUpdateIncome = async (formData: FormData) => {
       message: messages.incomeCreateSuccess,
       income
     }
-  } catch (error) {
-    return {
-      ok: false,
-      message: messages.incomeError
-    }
+  } catch {
+    return { ok: false, message: messages.incomeError }
   }
 }

--- a/src/actions/monedex/wallets/get-wallets-for-form.ts
+++ b/src/actions/monedex/wallets/get-wallets-for-form.ts
@@ -1,0 +1,33 @@
+'use server'
+
+import { unstable_noStore } from 'next/cache'
+import { getUserSessionServer } from '@/actions'
+import prisma from '@/lib/prisma'
+
+/**
+ * Returns a lightweight list of wallets for use in form selectors.
+ * Only includes id, name, and type — no balance or financial data.
+ */
+export const getWalletsForForm = async () => {
+  unstable_noStore()
+  const user = await getUserSessionServer()
+
+  if (!user) {
+    return { ok: false as const, message: 'Unauthorized', wallets: [] }
+  }
+
+  try {
+    const wallets = await prisma.wallet.findMany({
+      select: {
+        id: true,
+        name: true,
+        type: true
+      },
+      orderBy: { name: 'asc' }
+    })
+
+    return { ok: true as const, wallets }
+  } catch {
+    return { ok: false as const, message: 'Error fetching wallets', wallets: [] }
+  }
+}

--- a/src/app/monedex/dashboard/page.tsx
+++ b/src/app/monedex/dashboard/page.tsx
@@ -35,7 +35,7 @@ export default async function DashboardPage(props: { searchParams: SearchParams 
   }))
 
   return (
-    <section className="container mx-auto space-y-6 p-4">
+    <section>
       <div className="flex justify-between items-center">
         <Breadcrumbs breadcrumbs={[{ label: 'Wallets', href: '/monedex/wallets', active: true }]} />
         {/* Physical Amount Modal Trigger - Admin only */}
@@ -46,7 +46,7 @@ export default async function DashboardPage(props: { searchParams: SearchParams 
         )}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
         <MetricCard
           title="Total"
           balance={globalSummary.totalBalance}

--- a/src/app/monedex/expenses/[id]/edit/page.tsx
+++ b/src/app/monedex/expenses/[id]/edit/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 
+import { getWalletsForForm } from '@/actions/monedex/wallets/get-wallets-for-form'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import Form from '@/components/monedex/expenses/edit-form'
 import {
@@ -16,10 +17,11 @@ export default async function Page(props: {
   const params = await props.params
   const id = Number(params.id)
 
-  const [expense, categories, places] = await Promise.all([
+  const [expense, categories, places, walletsResult] = await Promise.all([
     fetchExpenseById(id),
     fetchCategoriesToForm(),
-    fetchPlaces()
+    fetchPlaces(),
+    getWalletsForForm()
   ])
 
   if (expense == null || categories == null) {
@@ -38,7 +40,7 @@ export default async function Page(props: {
           }
         ]}
       />
-      <Form expense={expense} categories={categories} places={places} />
+      <Form expense={expense} categories={categories} places={places} wallets={walletsResult.wallets} />
     </main>
   )
 }

--- a/src/app/monedex/expenses/create/page.tsx
+++ b/src/app/monedex/expenses/create/page.tsx
@@ -1,18 +1,27 @@
 import { type NextPage } from 'next'
 
 import { redirect } from 'next/navigation'
+import { getWalletsForForm } from '@/actions/monedex/wallets/get-wallets-for-form'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import Form from '@/components/monedex/expenses/create-form'
 import { fetchCategoriesToForm } from '@/lib/data'
 
 const Page: NextPage = async () => {
-  const [categories] = await Promise.all([
-    fetchCategoriesToForm()
+  const [categories, walletsResult] = await Promise.all([
+    fetchCategoriesToForm(),
+    getWalletsForForm()
   ])
 
   if (categories.length === 0) {
     redirect('/monedex/expenses')
   }
+
+  // Redirect if the user has no wallets — a wallet is required to record an expense
+  if (!walletsResult.ok || walletsResult.wallets.length === 0) {
+    redirect('/monedex/wallets')
+  }
+
+  const wallets = walletsResult.wallets
 
   return (
     <main>
@@ -26,7 +35,7 @@ const Page: NextPage = async () => {
           }
         ]}
       />
-      <Form categories={categories} />
+      <Form categories={categories} wallets={wallets} />
     </main>
   )
 }

--- a/src/app/monedex/incomes/[id]/page.tsx
+++ b/src/app/monedex/incomes/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { fetchIncomeById } from '@/actions/monedex/incomes/fetch-income-by-id'
 import { fetchIncomeCategoriesToForm } from '@/actions/monedex/incomes/fetch-income-categories-to-form'
+import { getWalletsForForm } from '@/actions/monedex/wallets/get-wallets-for-form'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import { IncomeForm } from '@/components/monedex/incomes/income-form'
 
@@ -12,9 +13,10 @@ export default async function IncomePage(props: {
   const params = await props.params
   const id = Number(params.id)
 
-  const [{ income }, categories] = await Promise.all([
+  const [{ income }, categories, walletsResult] = await Promise.all([
     fetchIncomeById(id),
-    fetchIncomeCategoriesToForm()
+    fetchIncomeCategoriesToForm(),
+    getWalletsForForm()
   ])
 
   if (!categories) {
@@ -37,7 +39,7 @@ export default async function IncomePage(props: {
           }
         ]}
       />
-      <IncomeForm income={income} categories={categories} />
+      <IncomeForm income={income} categories={categories} wallets={walletsResult.wallets} />
     </main>
   )
 }

--- a/src/app/monedex/incomes/create/page.tsx
+++ b/src/app/monedex/incomes/create/page.tsx
@@ -1,15 +1,22 @@
 import { redirect } from 'next/navigation'
 import { fetchIncomeCategoriesToForm } from '@/actions/monedex/incomes/fetch-income-categories-to-form'
+import { getWalletsForForm } from '@/actions/monedex/wallets/get-wallets-for-form'
 import Breadcrumbs from '@/components/monedex/breadcrumbs'
 import { IncomeForm } from '@/components/monedex/incomes/income-form'
 
 export default async function CreateIncomePage() {
-  const categories = await fetchIncomeCategoriesToForm()
-
-  // fetch categories
+  const [categories, walletsResult] = await Promise.all([
+    fetchIncomeCategoriesToForm(),
+    getWalletsForForm()
+  ])
 
   if (categories.length === 0) {
     redirect('/monedex/incomes')
+  }
+
+  // Redirect if the user has no wallets — a wallet is required to record an income
+  if (!walletsResult.ok || walletsResult.wallets.length === 0) {
+    redirect('/monedex/wallets')
   }
 
   return (
@@ -24,7 +31,7 @@ export default async function CreateIncomePage() {
           }
         ]}
       />
-      <IncomeForm income={null} categories={categories} />
+      <IncomeForm income={null} categories={categories} wallets={walletsResult.wallets} />
     </main>
   )
 }

--- a/src/components/monedex/expenses/create-form.tsx
+++ b/src/components/monedex/expenses/create-form.tsx
@@ -5,6 +5,7 @@ import { useFormState } from 'react-dom'
 import { BsCashStack } from 'react-icons/bs'
 import { FaDollarSign } from 'react-icons/fa'
 import { FaRegCreditCard } from 'react-icons/fa6'
+import { IoWalletOutline } from 'react-icons/io5'
 import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { ButtonBack } from '@/components/monedex/button-back'
@@ -12,12 +13,21 @@ import { ButtonSaved } from '@/components/monedex/button-saved'
 import { Calculator } from '@/components/ui/calculator'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { type Category } from '@/interfaces/Category'
+import { type WalletOption } from '@/interfaces/wallet.interface'
 import { createExpense } from '@/lib/actions'
 
+/** Returns the appropriate icon based on wallet type */
+function WalletTypeIcon({ type }: { type: WalletOption['type'] }) {
+  if (type === 'cash') return <BsCashStack className='h-4 w-4 inline ml-1' />
+  return <FaRegCreditCard className='h-4 w-4 inline ml-1' />
+}
+
 export default function Form({
-  categories
+  categories,
+  wallets
 }: {
   categories: Category[]
+  wallets: WalletOption[]
 }): JSX.Element {
   const initialState = { message: null, errors: {} }
   const [state, dispatch] = useFormState(createExpense, initialState)
@@ -26,10 +36,17 @@ export default function Form({
 
   const [amountValue, setAmountValue] = useState('')
   const [isCalculatorOpen, setIsCalculatorOpen] = useState(false)
+  const [selectedWallet, setSelectedWallet] = useState<WalletOption | null>(null)
+
+  const handleWalletChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const wallet = wallets.find(w => w.id === Number(e.target.value)) ?? null
+    setSelectedWallet(wallet)
+  }
 
   return (
     <form action={dispatch}>
       <div className='rounded-md bg-gray-50 p-4 md:p-6 max-w-2xl w-full mx-auto'>
+
         {/* Name */}
         <div className='mb-4'>
           <label htmlFor='name' className='mb-2 block text-sm font-medium'>
@@ -51,9 +68,7 @@ export default function Form({
           <div id='name-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.name &&
               state.errors.name.map((error: string) => (
-                <p className='mt-2 text-sm text-red-500' key={error}>
-                  {error}
-                </p>
+                <p className='mt-2 text-sm text-red-500' key={error}>{error}</p>
               ))}
           </div>
         </div>
@@ -92,80 +107,53 @@ export default function Form({
             </div>
           </div>
           <div id='amount-error' aria-live='polite' aria-atomic='true'>
-            {state.errors &&
-              state.errors.amount &&
+            {state.errors?.amount &&
               state.errors.amount.map((error: string) => (
-                <p className="mt-2 text-sm text-red-500" key={error}>
-                  {error}
-                </p>
+                <p className="mt-2 text-sm text-red-500" key={error}>{error}</p>
               ))}
           </div>
         </div>
 
-        {/* Method */}
-        <fieldset className='mb-4'>
-          <legend className='mb-2 block text-sm font-medium'>
-            Selecciona un método de pago
-          </legend>
-          <div className='rounded-md border border-gray-200 bg-white px-[14px] py-3'>
-            <div className='grid grid-cols-2 min-[400px]:grid-cols-3 gap-4'>
-              <div className='flex items-center'>
-                <input
-                  id='cash'
-                  name='method'
-                  type='radio'
-                  value='cash'
-                  aria-describedby='method-error'
-                  className='h-4 w-4 border-gray-300 bg-gray-100 text-gray-600' />
-                <label
-                  htmlFor='cash'
-                  className='flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
-                >
-                  Efectivo <BsCashStack className='h-4 w-4' />
-                </label>
-              </div>
-              <div className='flex items-center'>
-                <input
-                  id='debit'
-                  name='method'
-                  type='radio'
-                  value='debit'
-                  aria-describedby='method-error'
-                  className='h-4 w-4 border-gray-300 bg-gray-100 text-gray-600' />
-                <label
-                  htmlFor='debit'
-                  className='flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
-                >
-                  Débito <FaRegCreditCard className='h-4 w-4' />
-                </label>
-              </div>
-              <div className='flex items-center'>
-                <input
-                  id='credit'
-                  name='method'
-                  type='radio'
-                  value='credit'
-                  disabled
-                  aria-describedby='method-error'
-                  className='h-4 w-4 border-gray-300 bg-gray-100 text-gray-600' />
-                <label
-                  htmlFor='credit'
-                  className='flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
-                >
-                  Crédito <FaRegCreditCard className='h-4 w-4' />
-                </label>
-              </div>
-            </div>
+        {/* Wallet selector — replaces hardcoded cash/debit radio buttons */}
+        <div className='mb-4'>
+          <label htmlFor='walletId' className='mb-2 block text-sm font-medium'>
+            Selecciona una cartera
+          </label>
+          <div className='relative'>
+            <select
+              id='walletId'
+              name='walletId'
+              className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500'
+              defaultValue=''
+              aria-describedby='walletId-error'
+              onChange={handleWalletChange}
+            >
+              <option value='' disabled>Selecciona una cartera</option>
+              {wallets.map((wallet) => (
+                <option key={wallet.id} value={wallet.id}>{wallet.name}</option>
+              ))}
+            </select>
+            <IoWalletOutline className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
           </div>
-          <div id='method-error' aria-live='polite' aria-atomic='true'>
+
+          {/* Visual indicator of the selected wallet type */}
+          {selectedWallet && (
+            <span className='mt-1 inline-flex items-center text-xs text-gray-500'>
+              Tipo: {selectedWallet.type}
+              <WalletTypeIcon type={selectedWallet.type} />
+            </span>
+          )}
+
+          {/* Hidden field — sends the wallet type as method (derived from the selected wallet) */}
+          <input type='hidden' name='method' value={selectedWallet?.type ?? ''} />
+
+          <div id='walletId-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.method &&
               state.errors.method.map((error: string) => (
-                <p className='mt-2 text-sm text-red-500' key={error}>
-                  {error}
-                </p>
+                <p className='mt-2 text-sm text-red-500' key={error}>{error}</p>
               ))}
           </div>
-        </fieldset>
+        </div>
 
         {/* Category */}
         <div className='mb-4'>
@@ -180,13 +168,9 @@ export default function Form({
               defaultValue=''
               aria-describedby='category-error'
             >
-              <option value='' disabled>
-                Selecciona una categoría
-              </option>
+              <option value='' disabled>Selecciona una categoría</option>
               {categories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {category.name}
-                </option>
+                <option key={category.id} value={category.id}>{category.name}</option>
               ))}
             </select>
             <TbCategory className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
@@ -194,50 +178,14 @@ export default function Form({
           <div id='category-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.categoryId &&
               state.errors.categoryId.map((error: string) => (
-                <p className='mt-2 text-sm text-red-500' key={error}>
-                  {error}
-                </p>
+                <p className='mt-2 text-sm text-red-500' key={error}>{error}</p>
               ))}
           </div>
         </div>
 
-        {/* places */}
-        {/* <div className='mb-4'>
-          <label htmlFor='place' className='mb-2 block text-sm font-medium'>
-            Elige un lugar
-          </label>
-          <div className='relative'>
-            <select
-              id='place'
-              name='placeId'
-              className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500'
-              defaultValue=''
-              aria-describedby='place-error'
-            >
-              <option value='' disabled>
-                Selecciona un lugar
-              </option>
-              {places.map((place) => (
-                <option key={place.id} value={place.id}>
-                  {place.name}
-                </option>
-              ))}
-            </select>
-            <TbCategory className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
-          </div>
-          <div id='place-error' aria-live='polite' aria-atomic='true'>
-            {state.errors?.placeId &&
-              state.errors.placeId.map((error: string) => (
-                <p className='mt-2 text-sm text-red-500' key={error}>
-                  {error}
-                </p>
-              ))}
-          </div>
-        </div> */}
-
-        {/* Expense day */}
+        {/* Expense date */}
         <div className='mb-4'>
-          <label htmlFor='name' className='mb-2 block text-sm font-medium'>
+          <label htmlFor='expenseDate' className='mb-2 block text-sm font-medium'>
             Indica la fecha del gasto
           </label>
           <div className='relative mt-2 rounded-md'>
@@ -257,14 +205,12 @@ export default function Form({
           <div id='expenseDate-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.expenseDate &&
               state.errors.expenseDate.map((error: string) => (
-                <p className='mt-2 text-sm text-red-500' key={error}>
-                  {error}
-                </p>
+                <p className='mt-2 text-sm text-red-500' key={error}>{error}</p>
               ))}
           </div>
         </div>
 
-        {/* with relation */}
+        {/* With relation */}
         <div className='mb-4'>
           <div className='flex items-center gap-2'>
             <label htmlFor='withRelation' className='block text-sm font-medium'>
@@ -274,32 +220,28 @@ export default function Form({
               id='withRelation'
               name='withRelation'
               type='checkbox'
-              placeholder='Sí o No'
               aria-describedby='withRelation-error'
             />
-
           </div>
-
         </div>
 
-        {/*  Error all fields */}
+        {/* Global error message */}
         <div id='message-error' aria-live='polite' aria-atomic='true'>
           {state.message && (
             <p className='mt-2 text-sm text-red-500'>{state.message}</p>
           )}
         </div>
-        {/* buttons */}
-        <div className='mt-6 flex w-full justify-end text-left gap-4' >
-          <ButtonBack variant='destructive' name='Cancelar' className='text-monedex-light' />
 
+        {/* Action buttons */}
+        <div className='mt-6 flex w-full justify-end text-left gap-4'>
+          <ButtonBack variant='destructive' name='Cancelar' className='text-monedex-light' />
           <ButtonSaved
             className='text-monedex-light bg-monedex-tertiary hover:bg-monedex-tertiary/90'
             name='Agregar gasto'
           />
+        </div>
 
-        </div >
-      </div >
-
-    </form >
+      </div>
+    </form>
   )
 }

--- a/src/components/monedex/expenses/edit-form.tsx
+++ b/src/components/monedex/expenses/edit-form.tsx
@@ -6,6 +6,7 @@ import { useFormState } from 'react-dom'
 import { BsCashStack } from 'react-icons/bs'
 import { FaDollarSign } from 'react-icons/fa'
 import { FaRegCreditCard } from 'react-icons/fa6'
+import { IoWalletOutline } from 'react-icons/io5'
 import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { ButtonBack } from '@/components/monedex/button-back'
@@ -14,16 +15,25 @@ import { Calculator } from '@/components/ui/calculator'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { type Category } from '@/interfaces/Category'
 import { type ExpenseForm } from '@/interfaces/Expense'
+import { type WalletOption } from '@/interfaces/wallet.interface'
 import { updateExpense } from '@/lib/actions'
+
+/** Returns the appropriate icon based on wallet type */
+function WalletTypeIcon({ type }: { type: WalletOption['type'] }) {
+  if (type === 'cash') return <BsCashStack className='h-4 w-4 inline ml-1' />
+  return <FaRegCreditCard className='h-4 w-4 inline ml-1' />
+}
 
 export default function EditExpenseForm({
   expense,
   categories,
-  places
+  places,
+  wallets
 }: {
   expense: ExpenseForm
   categories: Category[]
   places: Array<{ id: number, name: string }>
+  wallets: WalletOption[]
 }): JSX.Element {
   const router = useRouter()
   const updateExpenseWithId = updateExpense.bind(null, Number(expense.id))
@@ -32,6 +42,15 @@ export default function EditExpenseForm({
 
   const [amountValue, setAmountValue] = useState(expense.amount.toString())
   const [isCalculatorOpen, setIsCalculatorOpen] = useState(false)
+
+  // Pre-select the wallet currently linked to this expense
+  const initialWallet = wallets.find(w => w.id === expense.wallet_id) ?? null
+  const [selectedWallet, setSelectedWallet] = useState<WalletOption | null>(initialWallet)
+
+  const handleWalletChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const wallet = wallets.find(w => w.id === Number(e.target.value)) ?? null
+    setSelectedWallet(wallet)
+  }
 
   useEffect(() => {
     if (state.message === 'Updated expense') {
@@ -42,6 +61,7 @@ export default function EditExpenseForm({
   return (
     <form action={dispatch}>
       <div className='rounded-md bg-gray-50 p-4 md:p-6'>
+
         {/* Name */}
         <div className='mb-4'>
           <label htmlFor='name' className='mb-2 block text-sm font-medium'>
@@ -63,9 +83,7 @@ export default function EditExpenseForm({
           </div>
           <div id='name-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.name?.map((error: string) => (
-              <p className='mt-2 text-sm text-red-500' key={`name:${error}`}>
-                {error}
-              </p>
+              <p className='mt-2 text-sm text-red-500' key={`name:${error}`}>{error}</p>
             ))}
           </div>
         </div>
@@ -105,79 +123,50 @@ export default function EditExpenseForm({
           </div>
           <div id='amount-error' aria-live='polite' aria-atomic='true'>
             {state?.errors?.amount?.map((error: string) => (
-              <p className='mt-2 text-sm text-red-500' key={`amount:${error}`}>
-                {error}
-              </p>
+              <p className='mt-2 text-sm text-red-500' key={`amount:${error}`}>{error}</p>
             ))}
           </div>
         </div>
 
-        {/* Method */}
-        <fieldset className='mb-4'>
-          <legend className='mb-2 block text-sm font-medium'>
-            Selecciona un método de pago
-          </legend>
-          <div className='rounded-md border border-gray-200 bg-white px-[14px] py-3'>
-            <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-              <div className='flex items-center'>
-                <input
-                  id='cash'
-                  name='method'
-                  type='radio'
-                  value='cash'
-                  aria-describedby='method-error'
-                  defaultChecked={expense.method === 'cash'}
-                  className='h-4 w-4 border-gray-300 bg-gray-100 text-gray-600' />
-                <label
-                  htmlFor='cash'
-                  className='flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
-                >
-                  Efectivo <BsCashStack className='h-4 w-4' />
-                </label>
-              </div>
-              <div className='flex items-center'>
-                <input
-                  id='debit'
-                  name='method'
-                  type='radio'
-                  value='debit'
-                  aria-describedby='method-error'
-                  defaultChecked={expense.method === 'debit'}
-                  className='h-4 w-4 border-gray-300 bg-gray-100 text-gray-600' />
-                <label
-                  htmlFor='debit'
-                  className='flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
-                >
-                  Débito <FaRegCreditCard className='h-4 w-4' />
-                </label>
-              </div>
-              <div className='flex items-center'>
-                <input
-                  id='credit'
-                  name='method'
-                  type='radio'
-                  value='credit'
-                  disabled
-                  aria-describedby='method-error'
-                  defaultChecked={expense.method === 'credit'}
-                  className='h-4 w-4 border-gray-300 bg-gray-100 text-gray-600' />
-                <label
-                  htmlFor='credit'
-                  className='flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300'
-                >
-                  Crédito <FaRegCreditCard className='h-4 w-4' />
-                </label>
-              </div>
-            </div>
+        {/* Wallet selector — replaces hardcoded cash/debit radio buttons */}
+        <div className='mb-4'>
+          <label htmlFor='walletId' className='mb-2 block text-sm font-medium'>
+            Selecciona una cartera
+          </label>
+          <div className='relative'>
+            <select
+              id='walletId'
+              name='walletId'
+              className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500'
+              defaultValue={expense.wallet_id ?? ''}
+              aria-describedby='walletId-error'
+              onChange={handleWalletChange}
+            >
+              <option value='' disabled>Selecciona una cartera</option>
+              {wallets.map((wallet) => (
+                <option key={wallet.id} value={wallet.id}>{wallet.name}</option>
+              ))}
+            </select>
+            <IoWalletOutline className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
           </div>
-          <div id='method-error' aria-live='polite' aria-atomic='true'>
+
+          {/* Visual indicator of the selected wallet type */}
+          {selectedWallet && (
+            <span className='mt-1 inline-flex items-center text-xs text-gray-500'>
+              Tipo: {selectedWallet.type}
+              <WalletTypeIcon type={selectedWallet.type} />
+            </span>
+          )}
+
+          {/* Hidden field — sends the wallet type as method (derived from the selected wallet) */}
+          <input type='hidden' name='method' value={selectedWallet?.type ?? ''} />
+
+          <div id='walletId-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.method?.map((error: string) => (
-              <p className='mt-2 text-sm text-red-500' key={`method:${error}`}>
-                {error}
-              </p>
+              <p className='mt-2 text-sm text-red-500' key={`method:${error}`}>{error}</p>
             ))}
           </div>
-        </fieldset>
+        </div>
 
         {/* Category */}
         <div className='mb-4'>
@@ -192,27 +181,21 @@ export default function EditExpenseForm({
               aria-describedby='category-error'
               defaultValue={expense.expense_category_id}
             >
-              <option value='' disabled>
-                Selecciona una categoría
-              </option>
+              <option value='' disabled>Selecciona una categoría</option>
               {categories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {category.name}
-                </option>
+                <option key={category.id} value={category.id}>{category.name}</option>
               ))}
             </select>
             <TbCategory className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
           </div>
           <div id='category-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.categoryId?.map((error: string) => (
-              <p className='mt-2 text-sm text-red-500' key={`category:${error}`}>
-                {error}
-              </p>
+              <p className='mt-2 text-sm text-red-500' key={`category:${error}`}>{error}</p>
             ))}
           </div>
         </div>
 
-        {/* place */}
+        {/* Place */}
         <div className='mb-4'>
           <label htmlFor='place' className='mb-2 block text-sm font-medium'>
             Elige un lugar
@@ -225,29 +208,23 @@ export default function EditExpenseForm({
               aria-describedby='place-error'
               defaultValue={expense.place_id}
             >
-              <option value='' disabled>
-                Selecciona un lugar
-              </option>
+              <option value='' disabled>Selecciona un lugar</option>
               {places.map((place) => (
-                <option key={place.id} value={place.id}>
-                  {place.name}
-                </option>
+                <option key={place.id} value={place.id}>{place.name}</option>
               ))}
             </select>
             <TbCategory className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
           </div>
           <div id='place-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.placeId?.map((error: string) => (
-              <p className='mt-2 text-sm text-red-500' key={`place:${error}`}>
-                {error}
-              </p>
+              <p className='mt-2 text-sm text-red-500' key={`place:${error}`}>{error}</p>
             ))}
           </div>
         </div>
 
-        {/* Expense day */}
+        {/* Expense date */}
         <div className='mb-4'>
-          <label htmlFor='name' className='mb-2 block text-sm font-medium'>
+          <label htmlFor='expenseDate' className='mb-2 block text-sm font-medium'>
             Indica la fecha del gasto
           </label>
           <div className='relative mt-2 rounded-md'>
@@ -266,14 +243,12 @@ export default function EditExpenseForm({
           </div>
           <div id='expenseDate-error' aria-live='polite' aria-atomic='true'>
             {state.errors?.expenseDate?.map((error: string) => (
-              <p className='mt-2 text-sm text-red-500' key={`expenseDate:${error}`}>
-                {error}
-              </p>
+              <p className='mt-2 text-sm text-red-500' key={`expenseDate:${error}`}>{error}</p>
             ))}
           </div>
         </div>
 
-        {/* with relation */}
+        {/* With relation */}
         <div className='mb-4'>
           <div className='flex items-center gap-2'>
             <label htmlFor='withRelation' className='block text-sm font-medium'>
@@ -283,31 +258,29 @@ export default function EditExpenseForm({
               id='withRelation'
               name='withRelation'
               type='checkbox'
-              placeholder='Sí o No'
               aria-describedby='withRelation-error'
               defaultChecked={expense.is_reconciled}
             />
-
           </div>
-
         </div>
 
-        {/*  Error all fields */}
+        {/* Global error message */}
         <div id='message-error' aria-live='polite' aria-atomic='true'>
           {state.message !== 'Updated expense' && (
             <p className='mt-2 text-sm text-red-500'>{state.message}</p>
           )}
         </div>
+
       </div>
 
-      {/* buttons */}
-      <div className='mt-6 flex w-full justify-end gap-4' >
+      {/* Action buttons */}
+      <div className='mt-6 flex w-full justify-end gap-4'>
         <ButtonBack variant='destructive' name='Cancelar' className='text-monedex-light' />
         <ButtonSaved
           className='text-monedex-light bg-monedex-tertiary hover:bg-monedex-tertiary/90'
           name={expense?.id ? 'Editar gasto' : 'Crear gasto'}
         />
-      </div >
+      </div>
     </form>
   )
 }

--- a/src/components/monedex/incomes/income-form.tsx
+++ b/src/components/monedex/incomes/income-form.tsx
@@ -6,10 +6,9 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
-import { BsCashStack } from 'react-icons/bs'
 import { FaDollarSign } from 'react-icons/fa'
-import { FaRegCreditCard } from 'react-icons/fa6'
 import { IoIosArrowDown } from 'react-icons/io'
+import { IoWalletOutline } from 'react-icons/io5'
 import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { z } from 'zod'
@@ -23,57 +22,47 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/componen
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { type Income, type IncomeCategory } from '@/interfaces/income.interface'
+import { type WalletOption } from '@/interfaces/wallet.interface'
 import { cn } from '@/lib/utils'
 
 const incomeSchema = z.object({
   id: z.number().optional().nullable(),
   name: z
-    .string({
-      required_error: 'El nombre es requerido.'
-    })
-    .min(3, {
-      message: 'El nombre debe tener al menos 3 caracteres.'
-    })
-    .max(100, {
-      message: 'El nombre debe tener máximo 100 caracteres.'
-    }),
+    .string({ required_error: 'El nombre es requerido.' })
+    .min(3, { message: 'El nombre debe tener al menos 3 caracteres.' })
+    .max(100, { message: 'El nombre debe tener máximo 100 caracteres.' }),
   amount: z
     .coerce.number({
       required_error: 'La cantidad es requerida.',
       invalid_type_error: 'La cantidad es requerida.'
-    }).gt(0, {
-      message: 'Por favor ingrese una cantidad mayor que $0.'
-    }),
-  method: z
-    .enum(['cash', 'debit'], {
-      required_error: 'El método de ingreso es requerido.'
-    }),
+    }).gt(0, { message: 'Por favor ingrese una cantidad mayor que $0.' }),
+  // walletId replaces the old hardcoded method (cash/debit) enum
+  walletId: z
+    .number({
+      required_error: 'La cartera es requerida.',
+      invalid_type_error: 'Selecciona una cartera válida.'
+    })
+    .int()
+    .min(1, { message: 'Selecciona una cartera.' }),
   incomeDate: z
     .date({
       required_error: 'La fecha del ingreso es requerida',
       invalid_type_error: 'Por favor ingresa una fecha valida.'
     }),
   incomeCategoryId: z
-    .number({
-      required_error: 'La categoría del ingreso es requerida.'
-    })
-    .int({
-      message: 'La categoría del ingreso debe ser un número entero.'
-    })
-    .min(1, {
-      message: 'La categoría del ingreso debe ser mayor o igual a 1.'
-    })
+    .number({ required_error: 'La categoría del ingreso es requerida.' })
+    .int({ message: 'La categoría del ingreso debe ser un número entero.' })
+    .min(1, { message: 'La categoría del ingreso debe ser mayor o igual a 1.' })
 })
 
 interface IncomeFormProps {
   income: Income | null
   categories: IncomeCategory[]
+  wallets: WalletOption[]
 }
 
-// TODO move to a toast component
 const noticeFailSaved = () => {
   toast.error('No se pudo guardar el ingreso, intente nuevamente', {
     position: 'top-right',
@@ -88,16 +77,19 @@ const noticeSuccessSaved = () => {
   })
 }
 
-export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
+export const IncomeForm = ({ income, categories, wallets }: IncomeFormProps) => {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isCalculatorAmountOpen, setIsCalculatorAmountOpen] = useState(false)
+
+  // Resolve the wallet that was previously linked to this income (for edit mode)
+  const initialWalletId = income?.wallet_id ? Number(income.wallet_id) : undefined
 
   const defaultValuesForm = {
     id: income?.id ? Number(income.id) : undefined,
     name: income?.name,
     amount: income?.amount,
-    method: income?.method as 'cash' | 'debit',
+    walletId: initialWalletId,
     incomeDate: income?.incomeDate ? new Date(income.incomeDate) : undefined,
     incomeCategoryId: income?.incomeCategory.id
   }
@@ -112,17 +104,15 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
 
     const formData = new FormData()
 
-    const { ...incomeToSave } = values
-
-    if (incomeToSave.id) {
-      formData.append('id', incomeToSave.id.toString())
+    if (values.id) {
+      formData.append('id', values.id.toString())
     }
 
-    formData.append('name', incomeToSave.name)
-    formData.append('amount', incomeToSave.amount.toString())
-    formData.append('method', incomeToSave.method)
-    formData.append('incomeDate', incomeToSave.incomeDate.toISOString())
-    formData.append('incomeCategoryId', incomeToSave.incomeCategoryId.toString())
+    formData.append('name', values.name)
+    formData.append('amount', values.amount.toString())
+    formData.append('walletId', values.walletId.toString())
+    formData.append('incomeDate', values.incomeDate.toISOString())
+    formData.append('incomeCategoryId', values.incomeCategoryId.toString())
 
     const { ok } = await createUpdateIncome(formData)
 
@@ -153,9 +143,7 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
               name='name'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>
-                    Nombre del ingreso
-                  </FormLabel>
+                  <FormLabel>Nombre del ingreso</FormLabel>
                   <FormControl>
                     <div className='relative rounded-md'>
                       <Input
@@ -178,9 +166,7 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
               name='amount'
               render={({ field }) => (
                 <FormItem className='mt-3'>
-                  <FormLabel>
-                    Cantidad
-                  </FormLabel>
+                  <FormLabel>Cantidad</FormLabel>
                   <FormControl>
                     <div className='relative rounded-md'>
                       <Popover open={isCalculatorAmountOpen} onOpenChange={setIsCalculatorAmountOpen}>
@@ -214,45 +200,42 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
               )}
             />
 
-            {/* Payment Method */}
+            {/* Wallet selector — replaces hardcoded cash/debit radio buttons */}
             <FormField
               control={form.control}
-              name='method'
+              name='walletId'
               render={({ field }) => (
                 <FormItem className='mt-3'>
-                  <FormLabel >
-                    Selecciona un método de ingreso
-                  </FormLabel>
+                  <FormLabel>Selecciona una cartera</FormLabel>
                   <FormControl>
-                    <RadioGroup
-                      onValueChange={field.onChange}
-                      defaultValue={field.value}
+                    <Select
+                      onValueChange={(value) => { field.onChange(Number(value)) }}
+                      defaultValue={field.value ? `${field.value}` : undefined}
                       disabled={isSubmitting}
-                      className="flex rounded-md border border-gray-200 bg-monedex-light p-3 text-gray-600 justify-start space-x-4"
                     >
-                      <FormItem className="flex items-center space-x-3 space-y-0">
-                        <FormControl>
-                          <RadioGroupItem value="cash" />
-                        </FormControl>
-                        <FormLabel className="text-xs">
+                      <SelectTrigger className='relative rounded-md border border-gray-200 bg-monedex-light p-3 text-gray-600'>
+                        <SelectValue>
                           <div className='flex gap-x-1 rounded-md'>
-                            Efectivo
-                            <BsCashStack className='h-4 w-4' />
+                            <IoWalletOutline className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
+                            <span className='pl-8'>
+                              {wallets.find(w => w.id === field.value)?.name ?? 'Selecciona una cartera'}
+                            </span>
                           </div>
-                        </FormLabel>
-                      </FormItem>
-                      <FormItem className="flex items-center space-x-1 space-y-0">
-                        <FormControl>
-                          <RadioGroupItem value="debit" />
-                        </FormControl>
-                        <FormLabel className="text-xs">
-                          <div className='flex gap-x-1 rounded-md'>
-                            Transferencia
-                            <FaRegCreditCard className='h-4 w-4' />
-                          </div>
-                        </FormLabel>
-                      </FormItem>
-                    </RadioGroup>
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent className='absolute z-10 w-full min-w-max bg-white rounded-md border border-gray-200 shadow-lg'>
+                        <SelectGroup>
+                          {wallets.map((wallet) => (
+                            <SelectItem
+                              key={wallet.id}
+                              value={`${wallet.id}`}
+                            >
+                              {wallet.name}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -265,14 +248,10 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
               name='incomeCategoryId'
               render={({ field }) => (
                 <FormItem className='mt-3'>
-                  <FormLabel>
-                    Selecciona una categoría
-                  </FormLabel>
+                  <FormLabel>Selecciona una categoría</FormLabel>
                   <FormControl>
                     <Select
-                      onValueChange={(value) => {
-                        field.onChange(Number(value))
-                      }}
+                      onValueChange={(value) => { field.onChange(Number(value)) }}
                       defaultValue={`${field.value}`}
                       disabled={isSubmitting}
                     >
@@ -306,6 +285,7 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
               )}
             />
 
+            {/* Income date */}
             <FormField
               control={form.control}
               name="incomeDate"
@@ -353,18 +333,18 @@ export const IncomeForm = ({ income, categories }: IncomeFormProps) => {
             />
           </CardContent>
           <CardFooter>
-            {/* buttons */}
-            <div className='mt-6 flex w-full justify-end gap-4' >
+            {/* Action buttons */}
+            <div className='mt-6 flex w-full justify-end gap-4'>
               <ButtonBack isSubmitting={isSubmitting} variant='destructive' name='Cancelar' className='text-monedex-light' />
               <ButtonSaved
                 className='text-monedex-light bg-monedex-tertiary hover:bg-monedex-tertiary/90'
                 isSubmitting={isSubmitting}
                 name={income?.id ? 'Editar ingreso' : 'Crear ingreso'}
               />
-            </div >
+            </div>
           </CardFooter>
-        </form >
-      </Card >
-    </Form >
+        </form>
+      </Card>
+    </Form>
   )
 }

--- a/src/interfaces/Expense.ts
+++ b/src/interfaces/Expense.ts
@@ -38,6 +38,7 @@ export interface ExpenseForm {
   expense_category_id: number
   place_id: number
   method: string
+  wallet_id: number
   is_reconciled: boolean
 }
 

--- a/src/interfaces/income.interface.ts
+++ b/src/interfaces/income.interface.ts
@@ -3,6 +3,7 @@ export interface Income {
   name: string
   amount: number
   method: string
+  wallet_id: number
   incomeDate: Date
   incomeMonth: number
   incomeCategoryId: number

--- a/src/interfaces/wallet.interface.ts
+++ b/src/interfaces/wallet.interface.ts
@@ -12,3 +12,10 @@ export interface WalletSummary {
     label: string
   }
 }
+
+/** Lightweight wallet shape used to populate form selectors (expense / income forms). */
+export interface WalletOption {
+  id: number
+  name: string
+  type: WalletType
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -32,8 +32,13 @@ const FormExpenseSchema = z.object({
   amount: z.coerce.number().gt(0, {
     message: 'Por favor ingrese una cantidad mayor que $0.'
   }),
-  method: z.enum(['cash', 'debit'], {
-    invalid_type_error: 'Seleccione un método de pago.'
+  // walletId replaces the old method enum — the user now selects a specific wallet
+  walletId: z.coerce.number().int().min(1, {
+    message: 'Seleccione una cartera.'
+  }),
+  // method is derived from wallet.type and sent by the form as a hidden field
+  method: z.string().min(1, {
+    message: 'Seleccione una cartera válida.'
   }),
   expenseDate: z.date({
     invalid_type_error: 'Por favor ingresa una fecha valida.'
@@ -86,6 +91,7 @@ export async function createExpense(
   const validatedFields = CreateExpenseSchema.safeParse({
     name: formData.get('name'),
     amount: formData.get('amount'),
+    walletId: formData.get('walletId'),
     method: formData.get('method'),
     expenseDate: expenseDateValue,
     expenseMonth: currentMonth,
@@ -116,18 +122,14 @@ export async function createExpense(
   }
 
   // Prepare data for insertion into the database
-  const { name, amount, categoryId, expenseDate, method, expenseMonth } =
+  const { name, amount, categoryId, expenseDate, method, expenseMonth, walletId } =
     validatedFields.data
 
   try {
-    const wallet = await prisma.wallet.findFirst({
-      where: {
-        type: method
-      },
-      select: {
-        id: true,
-        balance: true
-      }
+    // Fetch the selected wallet by its exact id — no longer looking up by type
+    const wallet = await prisma.wallet.findUnique({
+      where: { id: walletId },
+      select: { id: true, balance: true }
     })
 
     if (!wallet) {
@@ -248,6 +250,7 @@ export async function updateExpense(
   const validatedFields = UpdateExpense.safeParse({
     name: formData.get('name'),
     amount: formData.get('amount'),
+    walletId: formData.get('walletId'),
     method: formData.get('method'),
     expenseDate: expenseDateValue,
     expenseMonth: currentMonth,
@@ -263,7 +266,7 @@ export async function updateExpense(
   }
 
   // Prepare data for insertion into the database
-  const { name, amount, categoryId, expenseDate, method, expenseMonth } =
+  const { name, amount, categoryId, expenseDate, method, expenseMonth, walletId } =
     validatedFields.data
 
   try {
@@ -280,14 +283,10 @@ export async function updateExpense(
       return { message: 'Gasto no encontrado.' }
     }
 
-    // Get the new wallet according to the new method
-    const newWallet = await prisma.wallet.findFirst({
-      where: {
-        type: method
-      },
-      select: {
-        id: true
-      }
+    // Fetch the newly selected wallet by its exact id — no longer looking up by type
+    const newWallet = await prisma.wallet.findUnique({
+      where: { id: walletId },
+      select: { id: true }
     })
 
     if (!newWallet) {
@@ -296,8 +295,8 @@ export async function updateExpense(
       }
     }
 
-    // If the method has changed, we need to update the balance of the old wallet
-    if (oldExpense.method !== method) { // method has changed
+    // If the wallet changed, reverse the old balance and apply to the new wallet
+    if (oldExpense.wallet_id !== walletId) {
       // Update the old wallet balance
       await prisma.wallet.update({
         where: { id: oldExpense.wallet_id },

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -195,6 +195,7 @@ export async function fetchExpenseById(id: number): Promise<ExpenseForm> {
         expense_category_id: true,
         place_id: true,
         method: true,
+        wallet_id: true,
         with_relation: true,
         is_reconciled: true
       }


### PR DESCRIPTION
…et picker

### Changes Made

- feat: ✨ add `get-wallets-for-form` server action returning `{id, name, type}` per user
- refactor: 🧱 add `WalletOption` interface to `wallet.interface.ts`
- refactor: 🧱 replace radio buttons (cash/debit/credit) with `<select>` in `create-form.tsx`
- refactor: 🧱 replace radio buttons with wallet `<select>` + pre-selection in `edit-form.tsx`
- refactor: 🧱 replace `RadioGroup` with shadcn `<Select>` and `walletId` schema in `income-form.tsx`
- refactor: 🧱 update `createExpense` / `updateExpense` to use `wallet.findUnique(walletId)`
- refactor: 🧱 update `createUpdateIncome` to use `wallet.findUnique(walletId)` and derive `method` from `wallet.type`
- fix: 🐛 add `wallet_id` field to `ExpenseForm` and `Income` interfaces
- fix: 🐛 add `wallet_id` to `fetchExpenseById` Prisma select in `data.ts`
- feat: 🎨 load wallets in all 4 RSC pages and pass as prop to forms
- fix: 🐛 minor layout adjustments in `dashboard/page.tsx`

### Description of Changes

- Forms no longer show hardcoded type labels ("Efectivo", "Débito"). Users now select a specific named wallet (e.g. "BBVA Nómina", "Caja Principal").
- The `walletId` is sent from the form directly; backend uses `findUnique` instead of `findFirst({ where: { type } })`, eliminating the ambiguity of multiple wallets sharing the same type.
- The `method` field in the database is preserved for reporting/metrics by deriving it from `wallet.type` on the server side — no schema migration required.
- Wallet change detection in `updateExpense` now compares `wallet_id` directly instead of comparing `method` strings.