### PR TITLE
feat: ✨ responsive calculator + conciliado badge

### DIFF
--- a/src/actions/monedex/wallets/get-all-wallet-summary.ts
+++ b/src/actions/monedex/wallets/get-all-wallet-summary.ts
@@ -37,6 +37,9 @@ export const getAllWalletsSummary = async ({
 
   try {
     const walletSummaryDb = await prisma.wallet.findMany({
+      orderBy: {
+        type: 'asc'
+      },
       select: {
         id: true,
         name: true,

--- a/src/components/monedex/expenses/create-form.tsx
+++ b/src/components/monedex/expenses/create-form.tsx
@@ -1,26 +1,24 @@
 'use client'
 
+import { evaluate } from 'mathjs'
 import { useState } from 'react'
 import { useFormState } from 'react-dom'
-import { BsCashStack } from 'react-icons/bs'
 import { FaDollarSign } from 'react-icons/fa'
-import { FaRegCreditCard } from 'react-icons/fa6'
 import { IoWalletOutline } from 'react-icons/io5'
 import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { ButtonBack } from '@/components/monedex/button-back'
 import { ButtonSaved } from '@/components/monedex/button-saved'
 import { Calculator } from '@/components/ui/calculator'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { type Category } from '@/interfaces/Category'
 import { type WalletOption } from '@/interfaces/wallet.interface'
 import { createExpense } from '@/lib/actions'
 
 /** Returns the appropriate icon based on wallet type */
-function WalletTypeIcon({ type }: { type: WalletOption['type'] }) {
-  if (type === 'cash') return <BsCashStack className='h-4 w-4 inline ml-1' />
-  return <FaRegCreditCard className='h-4 w-4 inline ml-1' />
-}
+// function WalletTypeIcon({ type }: { type: WalletOption['type'] }) {
+//   if (type === 'cash') return <BsCashStack className='h-4 w-4 inline ml-1' />
+//   return <FaRegCreditCard className='h-4 w-4 inline ml-1' />
+// }
 
 export default function Form({
   categories,
@@ -80,29 +78,53 @@ export default function Form({
           </label>
           <div className='relative mt-2 rounded-md'>
             <div className='relative'>
-              <Popover open={isCalculatorOpen} onOpenChange={setIsCalculatorOpen}>
-                <PopoverTrigger asChild>
-                  <input
-                    id="amount"
-                    name="amount"
-                    type="text"
-                    readOnly
-                    value={amountValue}
-                    placeholder="Ingresa la cantidad"
-                    className="peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 cursor-pointer bg-white"
-                    aria-describedby="amount-error"
-                  />
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  <Calculator
-                    initialValue={amountValue}
-                    onResult={(val) => {
-                      setAmountValue(val.toString())
-                      setIsCalculatorOpen(false)
-                    }}
-                  />
-                </PopoverContent>
-              </Popover>
+              {/* Mobile input: readOnly, opens calculator */}
+              <input
+                id="amount-mobile"
+                name="amount"
+                type="text"
+                readOnly
+                value={amountValue}
+                placeholder="Ingresa la cantidad"
+                className="peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 cursor-pointer bg-white md:hidden"
+                aria-describedby="amount-error"
+                onClick={() => { setIsCalculatorOpen(true) }}
+              />
+              {/* Desktop input: editable, supports expressions */}
+              <input
+                id="amount"
+                name="amount"
+                type="text"
+                value={amountValue}
+                placeholder="Ingresa la cantidad (ej: 100+50)"
+                className="peer w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 bg-white hidden md:block"
+                aria-describedby="amount-error"
+                onChange={(e) => {
+                  const val = e.target.value
+                  if (val === '' || /^[\d+\-*/.() ]*$/.test(val)) {
+                    setAmountValue(val)
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    try {
+                      const result = evaluate(e.currentTarget.value)
+                      if (typeof result === 'number' && isFinite(result)) {
+                        setAmountValue(Number(result.toFixed(2)).toString())
+                      }
+                    } catch { /* ignore */ }
+                  }
+                }}
+                onBlur={(e) => {
+                  try {
+                    const result = evaluate(e.currentTarget.value)
+                    if (typeof result === 'number' && isFinite(result)) {
+                      setAmountValue(Number(result.toFixed(2)).toString())
+                    }
+                  } catch { /* ignore */ }
+                }}
+              />
               <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 z-10' />
             </div>
           </div>
@@ -114,11 +136,39 @@ export default function Form({
           </div>
         </div>
 
+        {/* Calculator bottom sheet - mobile only */}
+        {isCalculatorOpen && (
+          <>
+            <div
+              className='fixed inset-0 bg-black/30 z-40 md:hidden'
+              onClick={() => { setIsCalculatorOpen(false) }}
+            />
+            <div className='fixed bottom-0 inset-x-0 h-[50vh] z-50 md:hidden'>
+              <Calculator
+                initialValue={amountValue}
+                onClose={() => { setIsCalculatorOpen(false) }}
+                onResult={(val) => {
+                  setAmountValue(val.toString())
+                  setIsCalculatorOpen(false)
+                }}
+              />
+            </div>
+          </>
+        )}
+
         {/* Wallet selector — replaces hardcoded cash/debit radio buttons */}
         <div className='mb-4'>
           <label htmlFor='walletId' className='mb-2 block text-sm font-medium'>
             Selecciona una cartera
           </label>
+
+          {/* Visual indicator of the selected wallet type */}
+          {/* {selectedWallet && (
+            <span className='mt-1 inline-flex items-center text-xs text-gray-500'>
+              Tipo: {selectedWallet.type}
+              <WalletTypeIcon type={selectedWallet.type} />
+            </span>
+          )} */}
           <div className='relative'>
             <select
               id='walletId'
@@ -135,14 +185,6 @@ export default function Form({
             </select>
             <IoWalletOutline className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500' />
           </div>
-
-          {/* Visual indicator of the selected wallet type */}
-          {selectedWallet && (
-            <span className='mt-1 inline-flex items-center text-xs text-gray-500'>
-              Tipo: {selectedWallet.type}
-              <WalletTypeIcon type={selectedWallet.type} />
-            </span>
-          )}
 
           {/* Hidden field — sends the wallet type as method (derived from the selected wallet) */}
           <input type='hidden' name='method' value={selectedWallet?.type ?? ''} />

--- a/src/components/monedex/expenses/edit-form.tsx
+++ b/src/components/monedex/expenses/edit-form.tsx
@@ -1,28 +1,26 @@
 'use client'
 
+import { evaluate } from 'mathjs'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useFormState } from 'react-dom'
-import { BsCashStack } from 'react-icons/bs'
 import { FaDollarSign } from 'react-icons/fa'
-import { FaRegCreditCard } from 'react-icons/fa6'
 import { IoWalletOutline } from 'react-icons/io5'
 import { MdOutlineLocalGroceryStore, MdCalendarMonth } from 'react-icons/md'
 import { TbCategory } from 'react-icons/tb'
 import { ButtonBack } from '@/components/monedex/button-back'
 import { ButtonSaved } from '@/components/monedex/button-saved'
 import { Calculator } from '@/components/ui/calculator'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { type Category } from '@/interfaces/Category'
 import { type ExpenseForm } from '@/interfaces/Expense'
 import { type WalletOption } from '@/interfaces/wallet.interface'
 import { updateExpense } from '@/lib/actions'
 
 /** Returns the appropriate icon based on wallet type */
-function WalletTypeIcon({ type }: { type: WalletOption['type'] }) {
-  if (type === 'cash') return <BsCashStack className='h-4 w-4 inline ml-1' />
-  return <FaRegCreditCard className='h-4 w-4 inline ml-1' />
-}
+// function WalletTypeIcon({ type }: { type: WalletOption['type'] }) {
+//   if (type === 'cash') return <BsCashStack className='h-4 w-4 inline ml-1' />
+//   return <FaRegCreditCard className='h-4 w-4 inline ml-1' />
+// }
 
 export default function EditExpenseForm({
   expense,
@@ -95,29 +93,53 @@ export default function EditExpenseForm({
           </label>
           <div className='relative mt-2 rounded-md'>
             <div className='relative'>
-              <Popover open={isCalculatorOpen} onOpenChange={setIsCalculatorOpen}>
-                <PopoverTrigger asChild>
-                  <input
-                    id='amount'
-                    name='amount'
-                    type='text'
-                    readOnly
-                    placeholder='Ingresa la cantidad'
-                    className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 cursor-pointer bg-white'
-                    aria-describedby='amount-error'
-                    value={amountValue}
-                  />
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  <Calculator
-                    initialValue={amountValue}
-                    onResult={(val) => {
-                      setAmountValue(val.toString())
-                      setIsCalculatorOpen(false)
-                    }}
-                  />
-                </PopoverContent>
-              </Popover>
+              {/* Mobile input: readOnly, opens calculator */}
+              <input
+                id='amount-mobile'
+                name='amount'
+                type='text'
+                readOnly
+                placeholder='Ingresa la cantidad'
+                className='peer block w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 cursor-pointer bg-white md:hidden'
+                aria-describedby='amount-error'
+                value={amountValue}
+                onClick={() => { setIsCalculatorOpen(true) }}
+              />
+              {/* Desktop input: editable, supports expressions */}
+              <input
+                id='amount'
+                name='amount'
+                type='text'
+                placeholder='Ingresa la cantidad (ej: 100+50)'
+                className='peer w-full rounded-md border border-gray-200 py-2 pl-10 text-sm outline-2 placeholder:text-gray-500 bg-white hidden md:block'
+                aria-describedby='amount-error'
+                value={amountValue}
+                onChange={(e) => {
+                  const val = e.target.value
+                  if (val === '' || /^[\d+\-*/.() ]*$/.test(val)) {
+                    setAmountValue(val)
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    try {
+                      const result = evaluate(e.currentTarget.value)
+                      if (typeof result === 'number' && isFinite(result)) {
+                        setAmountValue(Number(result.toFixed(2)).toString())
+                      }
+                    } catch { /* ignore */ }
+                  }
+                }}
+                onBlur={(e) => {
+                  try {
+                    const result = evaluate(e.currentTarget.value)
+                    if (typeof result === 'number' && isFinite(result)) {
+                      setAmountValue(Number(result.toFixed(2)).toString())
+                    }
+                  } catch { /* ignore */ }
+                }}
+              />
               <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 z-10' />
             </div>
           </div>
@@ -127,6 +149,26 @@ export default function EditExpenseForm({
             ))}
           </div>
         </div>
+
+        {/* Calculator bottom sheet - mobile only */}
+        {isCalculatorOpen && (
+          <>
+            <div
+              className='fixed inset-0 bg-black/30 z-40 md:hidden'
+              onClick={() => { setIsCalculatorOpen(false) }}
+            />
+            <div className='fixed bottom-0 inset-x-0 h-[50vh] z-50 md:hidden'>
+              <Calculator
+                initialValue={amountValue}
+                onClose={() => { setIsCalculatorOpen(false) }}
+                onResult={(val) => {
+                  setAmountValue(val.toString())
+                  setIsCalculatorOpen(false)
+                }}
+              />
+            </div>
+          </>
+        )}
 
         {/* Wallet selector — replaces hardcoded cash/debit radio buttons */}
         <div className='mb-4'>
@@ -151,12 +193,12 @@ export default function EditExpenseForm({
           </div>
 
           {/* Visual indicator of the selected wallet type */}
-          {selectedWallet && (
+          {/* {selectedWallet && (
             <span className='mt-1 inline-flex items-center text-xs text-gray-500'>
               Tipo: {selectedWallet.type}
               <WalletTypeIcon type={selectedWallet.type} />
             </span>
-          )}
+          )} */}
 
           {/* Hidden field — sends the wallet type as method (derived from the selected wallet) */}
           <input type='hidden' name='method' value={selectedWallet?.type ?? ''} />

--- a/src/components/monedex/incomes/income-form.tsx
+++ b/src/components/monedex/incomes/income-form.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { format } from 'date-fns'
+import { evaluate } from 'mathjs'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -169,29 +170,51 @@ export const IncomeForm = ({ income, categories, wallets }: IncomeFormProps) => 
                   <FormLabel>Cantidad</FormLabel>
                   <FormControl>
                     <div className='relative rounded-md'>
-                      <Popover open={isCalculatorAmountOpen} onOpenChange={setIsCalculatorAmountOpen}>
-                        <PopoverTrigger asChild>
-                          <Input
-                            className='pl-10 text-sm bg-monedex-light cursor-pointer'
-                            placeholder='Ingresa la cantidad'
-                            {...field}
-                            value={field.value ?? ''}
-                            type='text'
-                            readOnly
-                            disabled={isSubmitting}
-                          />
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0" align="start">
-                          <Calculator
-                            initialValue={field.value?.toString() ?? ''}
-                            onResult={(val) => {
-                              form.setValue('amount', val)
+                      {/* Mobile input: readOnly, opens calculator */}
+                      <Input
+                        className='pl-10 text-sm bg-monedex-light cursor-pointer block md:hidden'
+                        placeholder='Ingresa la cantidad'
+                        value={field.value ?? ''}
+                        type='text'
+                        readOnly
+                        disabled={isSubmitting}
+                        onClick={() => { setIsCalculatorAmountOpen(true) }}
+                      />
+                      {/* Desktop input: editable, supports expressions */}
+                      <Input
+                        className='pl-10 text-sm bg-monedex-light hidden md:block'
+                        placeholder='Ingresa la cantidad (ej: 100+50)'
+                        value={field.value ?? ''}
+                        type='text'
+                        disabled={isSubmitting}
+                        onChange={(e) => {
+                          const val = e.target.value
+                          if (val === '' || /^[\d+\-*/.() ]*$/.test(val)) {
+                            form.setValue('amount', val === '' ? 0 : Number(val) || (val as unknown as number))
+                          }
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault()
+                            try {
+                              const result = evaluate(e.currentTarget.value)
+                              if (typeof result === 'number' && isFinite(result)) {
+                                form.setValue('amount', Number(result.toFixed(2)))
+                                form.trigger('amount')
+                              }
+                            } catch { /* ignore */ }
+                          }
+                        }}
+                        onBlur={(e) => {
+                          try {
+                            const result = evaluate(e.currentTarget.value)
+                            if (typeof result === 'number' && isFinite(result)) {
+                              form.setValue('amount', Number(result.toFixed(2)))
                               form.trigger('amount')
-                              setIsCalculatorAmountOpen(false)
-                            }}
-                          />
-                        </PopoverContent>
-                      </Popover>
+                            }
+                          } catch { /* ignore */ }
+                        }}
+                      />
                       <FaDollarSign className='pointer-events-none absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900 z-10' />
                     </div>
                   </FormControl>
@@ -199,6 +222,27 @@ export const IncomeForm = ({ income, categories, wallets }: IncomeFormProps) => 
                 </FormItem>
               )}
             />
+
+            {/* Calculator bottom sheet - mobile only */}
+            {isCalculatorAmountOpen && (
+              <>
+                <div
+                  className='fixed inset-0 bg-black/30 z-40 md:hidden'
+                  onClick={() => { setIsCalculatorAmountOpen(false) }}
+                />
+                <div className='fixed bottom-0 inset-x-0 h-[50vh] z-50 md:hidden'>
+                  <Calculator
+                    initialValue={form.getValues('amount')?.toString() ?? ''}
+                    onClose={() => { setIsCalculatorAmountOpen(false) }}
+                    onResult={(val) => {
+                      form.setValue('amount', val)
+                      form.trigger('amount')
+                      setIsCalculatorAmountOpen(false)
+                    }}
+                  />
+                </div>
+              </>
+            )}
 
             {/* Wallet selector — replaces hardcoded cash/debit radio buttons */}
             <FormField

--- a/src/components/monedex/transfers/TransferModal.tsx
+++ b/src/components/monedex/transfers/TransferModal.tsx
@@ -138,7 +138,7 @@ export function TransferModal({ open, onOpenChange }: TransferModalProps) {
               setDate(e.target.value)
             }} />
           </div>
-          <DialogFooter>
+          <DialogFooter className='gap-2'>
             <Button
               type="button"
               variant="outline"

--- a/src/components/monedex/wallets/MetricCard.tsx
+++ b/src/components/monedex/wallets/MetricCard.tsx
@@ -97,15 +97,21 @@ export function MetricCard({ title, balance, type, physicalAmount, difference, d
             <div className="flex items-center gap-1 text-sm">
               {
                 !excludeFromBalance && (
-                  <div
-                    className={cn(
-                      'flex items-center gap-0.5 px-1.5 py-0.5 rounded',
-                      isPositive ? 'bg-green-50 text-green-600' : 'bg-red-50 text-red-600'
-                    )}
-                  >
-                    <span className="text-xs">{isPositive ? '↗' : '↘'}</span>
-                    <span>{differencePercentage?.toFixed(2) ?? '0.00'}%</span>
-                  </div>
+                  differencePercentage === 0
+                    ? (
+                      <Badge className="bg-green-100 text-green-700 hover:bg-green-100 text-xs uppercase">
+                        Conciliado
+                      </Badge>)
+                    : (
+                      <div
+                        className={cn(
+                          'flex items-center gap-0.5 px-1.5 py-0.5 rounded',
+                          isPositive ? 'bg-green-50 text-green-600' : 'bg-red-50 text-red-600'
+                        )}
+                      >
+                        <span className="text-xs">{isPositive ? '↗' : '↘'}</span>
+                        <span>{differencePercentage?.toFixed(2) ?? '0.00'}%</span>
+                      </div>)
                 )
               }
             </div>

--- a/src/components/monedex/wallets/physical-amount-modal.tsx
+++ b/src/components/monedex/wallets/physical-amount-modal.tsx
@@ -178,7 +178,7 @@ export function PhysicalAmountModal({ wallets }: PhysicalAmountModalProps) {
               </div>
             </div>
           </div>
-          <DialogFooter>
+          <DialogFooter className='gap-2'>
             <Button
               type="button"
               variant="outline"

--- a/src/components/ui/calculator.tsx
+++ b/src/components/ui/calculator.tsx
@@ -1,16 +1,19 @@
 'use client'
 
-import { Delete } from 'lucide-react'
+import { Delete, X } from 'lucide-react'
 import { evaluate } from 'mathjs'
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 interface CalculatorProps {
   onResult: (value: number) => void
   initialValue?: string
+  onClose?: () => void
+  className?: string
 }
 
-export function Calculator({ onResult, initialValue }: CalculatorProps) {
+export function Calculator({ onResult, initialValue, onClose, className }: CalculatorProps) {
   const [expression, setExpression] = useState(initialValue && initialValue !== '' ? initialValue : '0')
   const [error, setError] = useState(false)
 
@@ -67,43 +70,58 @@ export function Calculator({ onResult, initialValue }: CalculatorProps) {
     }
   }
 
-  const btnClass = 'text-lg font-medium py-6'
-  const actionBtnClass = 'text-lg font-medium py-6 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-100 hover:bg-slate-200 dark:hover:bg-slate-700'
-  const accentBtnClass = 'text-lg font-medium py-6 bg-blue-500 hover:bg-blue-600 text-white'
+  const btnClass = 'text-lg font-medium flex-1 min-h-0'
+  const actionBtnClass = 'text-lg font-medium flex-1 min-h-0 bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-100 hover:bg-slate-200 dark:hover:bg-slate-700'
+  const accentBtnClass = 'text-lg font-medium flex-1 min-h-0 bg-blue-500 hover:bg-blue-600 text-white'
 
   return (
-    <div className='w-full max-w-sm mx-auto p-4 bg-white dark:bg-slate-950 rounded-xl shadow-sm border border-slate-200 dark:border-slate-800'>
-      <div className='mb-4 p-4 text-right bg-slate-50 dark:bg-slate-900 rounded-lg min-h-[80px] flex flex-col justify-center overflow-x-auto border border-slate-100 dark:border-slate-800'>
-        <div className={`text-3xl font-semibold tracking-tight ${error ? 'text-red-500' : 'text-slate-900 dark:text-slate-50'}`}>
+    <div className={cn('w-full flex flex-col h-full p-3 bg-white dark:bg-slate-950 rounded-t-xl shadow-sm border border-slate-200 dark:border-slate-800', className)}>
+      {/* Header with close button */}
+      {onClose && (
+        <div className='flex justify-end mb-1'>
+          <button
+            type='button'
+            onClick={onClose}
+            className='p-1 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors'
+          >
+            <X className='w-5 h-5 text-slate-500' />
+          </button>
+        </div>
+      )}
+
+      {/* Display */}
+      <div className='mb-2 p-3 text-right bg-slate-50 dark:bg-slate-900 rounded-lg min-h-[56px] flex flex-col justify-center overflow-x-auto border border-slate-100 dark:border-slate-800'>
+        <div className={`text-2xl font-semibold tracking-tight ${error ? 'text-red-500' : 'text-slate-900 dark:text-slate-50'}`}>
           {error ? 'Error' : expression}
         </div>
       </div>
 
-      <div className='grid grid-cols-4 gap-2'>
-        <Button variant='outline' className={actionBtnClass} onClick={handleClear}>C</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={handleBackspace}>
+      {/* Button grid - fills remaining space */}
+      <div className='grid grid-cols-4 gap-1.5 flex-1'>
+        <Button type='button' variant='outline' className={actionBtnClass} onClick={handleClear}>C</Button>
+        <Button type='button' variant='outline' className={actionBtnClass} onClick={handleBackspace}>
           <Delete className='w-5 h-5' />
         </Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('÷') }}>÷</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('×') }}>×</Button>
+        <Button type='button' variant='outline' className={actionBtnClass} onClick={() => { handlePress('÷') }}>÷</Button>
+        <Button type='button' variant='outline' className={actionBtnClass} onClick={() => { handlePress('×') }}>×</Button>
 
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('7') }}>7</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('8') }}>8</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('9') }}>9</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('-') }}>-</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('7') }}>7</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('8') }}>8</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('9') }}>9</Button>
+        <Button type='button' variant='outline' className={actionBtnClass} onClick={() => { handlePress('-') }}>-</Button>
 
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('4') }}>4</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('5') }}>5</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('6') }}>6</Button>
-        <Button variant='outline' className={actionBtnClass} onClick={() => { handlePress('+') }}>+</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('4') }}>4</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('5') }}>5</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('6') }}>6</Button>
+        <Button type='button' variant='outline' className={actionBtnClass} onClick={() => { handlePress('+') }}>+</Button>
 
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('1') }}>1</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('2') }}>2</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('3') }}>3</Button>
-        <Button variant='default' className={`${accentBtnClass} row-span-2 h-full`} onClick={handleEqual}>=</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('1') }}>1</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('2') }}>2</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('3') }}>3</Button>
+        <Button type='button' variant='default' className={`${accentBtnClass} row-span-2`} onClick={handleEqual}>=</Button>
 
-        <Button variant='outline' className={`${btnClass} col-span-2`} onClick={() => { handlePress('0') }}>0</Button>
-        <Button variant='outline' className={btnClass} onClick={() => { handlePress('.') }}>.</Button>
+        <Button type='button' variant='outline' className={`${btnClass} col-span-2`} onClick={() => { handlePress('0') }}>0</Button>
+        <Button type='button' variant='outline' className={btnClass} onClick={() => { handlePress('.') }}>.</Button>
       </div>
     </div>
   )


### PR DESCRIPTION
### Changes Made

- feat: ✨ responsive calculator with mobile bottom sheet and desktop keyboard input
- fix: 🐛 add type='button' to calculator buttons to prevent form submission
- feat: 🏷️ show "Conciliado" badge in MetricCard when difference is 0%
- refactor: 🧱 remove Popover dependency from expense and income forms
- style: 💄 make calculator flexible layout with adaptive buttons

### Description of Changes

- Replaced Popover-based calculator with a responsive approach: mobile shows a fixed bottom sheet (50vh), desktop shows an editable input supporting math expressions (e.g. 100+50) evaluated via mathjs on Enter/blur
- Two inputs per form using Tailwind responsive classes (block md:hidden / hidden md:block) to differentiate behavior without JS viewport detection
- Added type='button' to all Calculator buttons to prevent accidental form submission when rendered inside forms
- MetricCard now displays a green "Conciliado" badge when differencePercentage equals 0 instead of showing 0% with an arrow
- Minor UI tweaks: DialogFooter gap in physical-amount-modal, wallet summary query update