### PR TITLE
fix: 🐛 fix floating-point precision in wallets

### DIFF
--- a/src/actions/monedex/wallets/get-all-wallet-summary.ts
+++ b/src/actions/monedex/wallets/get-all-wallet-summary.ts
@@ -4,6 +4,9 @@ import { unstable_noStore } from 'next/cache'
 import { getUserSessionServer } from '@/actions'
 import prisma from '@/lib/prisma'
 
+/** Rounds a number to 2 decimal places to avoid floating-point precision issues */
+const round2 = (n: number): number => Math.round(n * 100) / 100
+
 const messages = {
   success: 'Wallet summary get successfully',
   error: 'Error getting wallet summary'
@@ -104,13 +107,13 @@ export const getAllWalletsSummary = async ({
 
     const walletsSummary = walletSummaryDb.map(wallet => {
       // calculate total income and expenses
-      const totalIncome = wallet.incomes.reduce((total, income) => total + income.amount, 0)
-      const totalExpenses = wallet.expenses.reduce((total, expense) => total + expense.amount, 0)
-      const totalIncomingTransfers = wallet.incomingTransfers.reduce((total, t) => total + t.amount, 0)
-      const totalOutgoingTransfers = wallet.outgoingTransfers.reduce((total, t) => total + t.amount, 0)
+      const totalIncome = round2(wallet.incomes.reduce((total, income) => total + income.amount, 0))
+      const totalExpenses = round2(wallet.expenses.reduce((total, expense) => total + expense.amount, 0))
+      const totalIncomingTransfers = round2(wallet.incomingTransfers.reduce((total, t) => total + t.amount, 0))
+      const totalOutgoingTransfers = round2(wallet.outgoingTransfers.reduce((total, t) => total + t.amount, 0))
 
       // Calculate change in balance
-      const balance = totalIncome - totalExpenses + totalIncomingTransfers - totalOutgoingTransfers
+      const balance = round2(totalIncome - totalExpenses + totalIncomingTransfers - totalOutgoingTransfers)
       const physical = wallet.physical ?? 0
 
       if (!wallet.excludeFromBalance) {
@@ -122,9 +125,9 @@ export const getAllWalletsSummary = async ({
 
       const changeValue = totalExpenses > 0 ? ((totalIncome - totalExpenses) / totalExpenses) * 100 : 0
       const changeLabel = 'Balance financiero'
-      const difference = (wallet.physical ?? 0) - balance
+      const difference = round2((wallet.physical ?? 0) - balance)
 
-      const differencePercentage = balance !== 0 ? (difference / balance) * 100 : 0
+      const differencePercentage = round2(balance !== 0 ? (difference / balance) * 100 : 0)
 
       return {
         id: wallet.id,
@@ -142,12 +145,12 @@ export const getAllWalletsSummary = async ({
       }
     })
 
-    const globalDifference = totalPhysicalGlobal - totalBalanceGlobal
+    const globalDifference = round2(totalPhysicalGlobal - totalBalanceGlobal)
     const globalDifferencePercentage =
-      totalBalanceGlobal !== 0 ? (globalDifference / totalBalanceGlobal) * 100 : 0
-    const globalChangeValue = totalExpensesGlobal > 0
+      round2(totalBalanceGlobal !== 0 ? (globalDifference / totalBalanceGlobal) * 100 : 0)
+    const globalChangeValue = round2(totalExpensesGlobal > 0
       ? ((totalIncomeGlobal - totalExpensesGlobal) / totalExpensesGlobal) * 100
-      : 0
+      : 0)
     const globalChangeLabel = 'Balance total'
     const globalSummary = {
       totalIncome: totalIncomeGlobal,


### PR DESCRIPTION
### Changes Made

- fix: 🐛 round all monetary calculations to 2 decimals
- refactor: 🧱 add `round2` utility helper function

### Description of Changes

- JavaScript floating-point arithmetic caused accumulated rounding errors in wallet balance calculations (e.g., `31.330000014` instead of `31.33`)
- Added a `round2` helper using `Math.round(n * 100) / 100` to ensure 2-decimal precision
- Applied rounding to all monetary aggregations: incomes, expenses, transfers, balances, differences, and global summaries
- Fixes discrepancies between calculated balance and physically entered values